### PR TITLE
Fix ESLint errors in test files

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import {
   getHealthStatus,

--- a/frontend/src/components/resources/ResourceFilters.test.tsx
+++ b/frontend/src/components/resources/ResourceFilters.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/test/test-utils';
+import { render, screen, fireEvent } from '@/test/test-utils';
 import { ResourceFilters } from './ResourceFilters';
 
 describe('ResourceFilters', () => {

--- a/frontend/src/components/topology/InfrastructureTopology.test.tsx
+++ b/frontend/src/components/topology/InfrastructureTopology.test.tsx
@@ -2,9 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@/test/test-utils';
 import { InfrastructureTopology } from './InfrastructureTopology';
 
+// Mock interfaces for topology components
+interface MockTopologyCanvasProps {
+  data?: { vpcs?: { vpc_id: string }[] };
+  onNodeClick?: (id: string, type: string, data: { label: string; type: string }) => void;
+}
+
+interface MockTopologyLegendProps {
+  stats?: { total_vpcs: number };
+}
+
 // Mock the topology components
 vi.mock('./TopologyCanvas', () => ({
-  TopologyCanvas: ({ data, onNodeClick }: any) => (
+  TopologyCanvas: ({ data, onNodeClick }: MockTopologyCanvasProps) => (
     <div data-testid="topology-canvas">
       <button
         data-testid="test-node"
@@ -18,7 +28,7 @@ vi.mock('./TopologyCanvas', () => ({
 }));
 
 vi.mock('./TopologyLegend', () => ({
-  TopologyLegend: ({ stats }: any) => (
+  TopologyLegend: ({ stats }: MockTopologyLegendProps) => (
     <div data-testid="topology-legend">
       {stats && <span>Stats: {stats.total_vpcs} VPCs</span>}
     </div>

--- a/frontend/src/components/topology/TopologyCanvas.test.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.test.tsx
@@ -2,9 +2,23 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { TopologyCanvas } from './TopologyCanvas';
 
+// Mock interfaces for ReactFlow
+interface MockReactFlowProps {
+  children?: React.ReactNode;
+  nodes?: unknown[];
+  edges?: unknown[];
+  onNodeClick?: (event: React.MouseEvent, node: { id: string; type: string; data: { label: string } }) => void;
+}
+
+interface MockNode {
+  id: string;
+  position: { x: number; y: number };
+  data: unknown;
+}
+
 // Mock ReactFlow and related imports
 vi.mock('reactflow', () => ({
-  default: ({ children, nodes, edges, onNodeClick }: any) => (
+  default: ({ children, nodes, edges, onNodeClick }: MockReactFlowProps) => (
     <div data-testid="react-flow" data-nodes={JSON.stringify(nodes)} data-edges={JSON.stringify(edges)}>
       <button data-testid="mock-node" onClick={(e) => onNodeClick?.(e, { id: 'node-1', type: 'ec2', data: { label: 'test' } })}>
         Mock Node
@@ -14,8 +28,8 @@ vi.mock('reactflow', () => ({
   ),
   Background: () => <div data-testid="react-flow-background" />,
   Controls: () => <div data-testid="react-flow-controls" />,
-  useNodesState: (initialNodes: any[]) => [initialNodes, vi.fn(), vi.fn()],
-  useEdgesState: (initialEdges: any[]) => [initialEdges, vi.fn(), vi.fn()],
+  useNodesState: (initialNodes: MockNode[]) => [initialNodes, vi.fn(), vi.fn()],
+  useEdgesState: (initialEdges: { id: string; source: string; target: string }[]) => [initialEdges, vi.fn(), vi.fn()],
   BackgroundVariant: { Dots: 'dots' },
 }));
 

--- a/frontend/src/components/vpc/VPCList.test.tsx
+++ b/frontend/src/components/vpc/VPCList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
+import { render, screen } from '@/test/test-utils';
 import { VPCList } from './VPCList';
 
 const mockVPCs = [

--- a/frontend/src/pages/EC2List.test.tsx
+++ b/frontend/src/pages/EC2List.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
+import { render, screen } from '@/test/test-utils';
 import { EC2ListPage } from './EC2List';
 
 // Mock the hooks

--- a/frontend/src/pages/TopologyPage.test.tsx
+++ b/frontend/src/pages/TopologyPage.test.tsx
@@ -3,8 +3,15 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { TopologyPage } from './TopologyPage';
 
 // Mock the InfrastructureTopology component
+interface TopologyNodeData {
+  type: string;
+  label: string;
+  tfManaged?: boolean;
+  [key: string]: unknown;
+}
+
 vi.mock('@/components/topology', () => ({
-  InfrastructureTopology: ({ onResourceSelect }: { onResourceSelect: (data: any) => void }) => (
+  InfrastructureTopology: ({ onResourceSelect }: { onResourceSelect: (data: TopologyNodeData) => void }) => (
     <div data-testid="infrastructure-topology">
       <button
         data-testid="ec2-node"

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';


### PR DESCRIPTION
- Remove unused imports (afterEach, waitFor, fireEvent)
- Replace 'any' types with proper interface definitions in topology test mocks
- Add eslint-disable comment for react-refresh rule in test-utils.tsx

https://claude.ai/code/session_01ERhc66wf4pSUzaX6pfsT55