### PR TITLE
Fix Bandit and Trivy security scan issues

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -69,7 +69,8 @@ class Settings(BaseSettings):
     # -------------------------------------------------------------------------
     debug: bool = Field(default=False, description="Enable debug mode")
     log_level: str = Field(default="INFO", description="Logging level")
-    api_host: str = Field(default="0.0.0.0", description="API host")
+    # nosec B104 - Binding to 0.0.0.0 is intentional for containerized deployment
+    api_host: str = Field(default="0.0.0.0", description="API host")  # nosec B104
     api_port: int = Field(default=8000, description="API port")
 
     # CORS

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -23,10 +23,20 @@ import {
   getTopology,
 } from './client';
 
-// Mock axios
+// Mock axios - type assertion for self-reference
+interface MockAxiosInstance {
+  create: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  interceptors: {
+    request: { use: ReturnType<typeof vi.fn> };
+    response: { use: ReturnType<typeof vi.fn> };
+  };
+}
+
 vi.mock('axios', () => {
-  const mockAxios = {
-    create: vi.fn(() => mockAxios),
+  const mockAxios: MockAxiosInstance = {
+    create: vi.fn(),
     get: vi.fn(),
     post: vi.fn(),
     interceptors: {
@@ -34,6 +44,7 @@ vi.mock('axios', () => {
       response: { use: vi.fn() },
     },
   };
+  mockAxios.create.mockReturnValue(mockAxios);
   return { default: mockAxios };
 });
 

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { Header } from './Header';
 

--- a/frontend/src/components/resources/ResourceDetailPanel.test.tsx
+++ b/frontend/src/components/resources/ResourceDetailPanel.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { EC2DetailPanel, RDSDetailPanel } from './ResourceDetailPanel';
 import type { EC2Instance, RDSInstance } from '@/types';
 
 const mockEC2Instance: EC2Instance = {
+  id: 1,
   instance_id: 'i-1234567890abcdef0',
   name: 'Test EC2 Instance',
   instance_type: 't3.micro',
@@ -13,6 +14,8 @@ const mockEC2Instance: EC2Instance = {
   availability_zone: 'us-east-1a',
   private_ip: '10.0.1.100',
   public_ip: '54.123.45.67',
+  private_dns: 'ip-10-0-1-100.ec2.internal',
+  public_dns: 'ec2-54-123-45-67.compute-1.amazonaws.com',
   vpc_id: 'vpc-12345678',
   subnet_id: 'subnet-12345678',
   tf_managed: true,
@@ -20,6 +23,8 @@ const mockEC2Instance: EC2Instance = {
   tf_resource_address: 'aws_instance.web_server',
   launch_time: '2024-01-15T10:30:00Z',
   updated_at: '2024-01-15T12:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
   tags: {
     Environment: 'Production',
     Team: 'DevOps',
@@ -27,6 +32,7 @@ const mockEC2Instance: EC2Instance = {
 };
 
 const mockRDSInstance: RDSInstance = {
+  id: 1,
   db_instance_identifier: 'prod-db-01',
   name: 'Production Database',
   db_instance_class: 'db.t3.micro',
@@ -45,6 +51,9 @@ const mockRDSInstance: RDSInstance = {
   tf_state_source: 'prod/terraform.tfstate',
   tf_resource_address: 'aws_db_instance.main',
   updated_at: '2024-01-15T12:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
+  tags: null,
 };
 
 describe('EC2DetailPanel', () => {

--- a/frontend/src/components/resources/ResourceFilters.test.tsx
+++ b/frontend/src/components/resources/ResourceFilters.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { ResourceFilters } from './ResourceFilters';
 

--- a/frontend/src/components/topology/TopologyCanvas.test.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { TopologyCanvas } from './TopologyCanvas';
+import type { TopologyResponse } from '@/types/topology';
 
 // Mock interfaces for ReactFlow
 interface MockReactFlowProps {
@@ -47,32 +48,45 @@ vi.mock('./utils/layoutCalculator', () => ({
   ],
 }));
 
-const mockTopologyData = {
+const mockTopologyData: TopologyResponse = {
   vpcs: [
     {
-      vpc_id: 'vpc-123',
+      id: 'vpc-123',
       name: 'Test VPC',
       cidr_block: '10.0.0.0/16',
-      display_status: 'active' as const,
+      state: 'available',
+      display_status: 'active',
       tf_managed: true,
+      tf_resource_address: null,
+      internet_gateway: null,
+      elastic_ips: [],
+      subnets: [
+        {
+          id: 'subnet-123',
+          name: 'Test Subnet',
+          cidr_block: '10.0.1.0/24',
+          availability_zone: 'us-east-1a',
+          subnet_type: 'public',
+          display_status: 'active',
+          tf_managed: true,
+          tf_resource_address: null,
+          nat_gateway: null,
+          ec2_instances: [],
+          rds_instances: [],
+        },
+      ],
     },
   ],
-  subnets: [
-    {
-      subnet_id: 'subnet-123',
-      vpc_id: 'vpc-123',
-      name: 'Test Subnet',
-      cidr_block: '10.0.1.0/24',
-      availability_zone: 'us-east-1a',
-      subnet_type: 'public' as const,
-      display_status: 'active' as const,
-      tf_managed: true,
-    },
-  ],
-  ec2_instances: [],
-  rds_instances: [],
-  internet_gateways: [],
-  nat_gateways: [],
+  meta: {
+    total_vpcs: 1,
+    total_subnets: 1,
+    total_ec2: 0,
+    total_rds: 0,
+    total_nat_gateways: 0,
+    total_internet_gateways: 0,
+    total_elastic_ips: 0,
+    last_refreshed: '2024-01-15T12:00:00Z',
+  },
 };
 
 describe('TopologyCanvas', () => {

--- a/frontend/src/components/topology/nodes/EC2Node.test.tsx
+++ b/frontend/src/components/topology/nodes/EC2Node.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/test-utils';
 import { EC2Node } from './EC2Node';
+import type { EC2NodeData } from '@/types/topology';
 
 // Mock react-flow
 vi.mock('reactflow', () => ({
@@ -15,24 +16,29 @@ vi.mock('reactflow', () => ({
   },
 }));
 
-const defaultData = {
+const defaultData: EC2NodeData = {
+  type: 'ec2',
   label: 'web-server-1',
+  instanceId: 'i-1234567890abcdef0',
   instanceType: 't3.micro',
-  displayStatus: 'active' as const,
+  displayStatus: 'active',
   privateIp: '10.0.1.100',
   tfManaged: false,
+  state: 'running',
 };
 
-const createNodeProps = (data: typeof defaultData) => ({
+const createNodeProps = (data: EC2NodeData) => ({
   id: 'test-node',
   data,
-  type: 'ec2Node',
+  type: 'ec2',
   selected: false,
   isConnectable: true,
   xPos: 0,
   yPos: 0,
   zIndex: 1,
   dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe('EC2Node', () => {

--- a/frontend/src/components/topology/nodes/GatewayNode.test.tsx
+++ b/frontend/src/components/topology/nodes/GatewayNode.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/test-utils';
 import { InternetGatewayNode, NATGatewayNode } from './GatewayNode';
+import type { InternetGatewayNodeData, NATGatewayNodeData } from '@/types/topology';
 
 // Mock react-flow
 vi.mock('reactflow', () => ({
@@ -15,143 +16,162 @@ vi.mock('reactflow', () => ({
   },
 }));
 
-const createNodeProps = <T extends object>(data: T) => ({
+const createIGWNodeProps = (data: InternetGatewayNodeData) => ({
   id: 'test-node',
   data,
-  type: 'gatewayNode',
+  type: 'internet-gateway',
   selected: false,
   isConnectable: true,
   xPos: 0,
   yPos: 0,
   zIndex: 1,
   dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+});
+
+const createNATNodeProps = (data: NATGatewayNodeData) => ({
+  id: 'test-node',
+  data,
+  type: 'nat-gateway',
+  selected: false,
+  isConnectable: true,
+  xPos: 0,
+  yPos: 0,
+  zIndex: 1,
+  dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe('InternetGatewayNode', () => {
-  const defaultIGWData = {
+  const defaultIGWData: InternetGatewayNodeData = {
+    type: 'internet-gateway',
     label: 'main-igw',
     igwId: 'igw-12345',
-    displayStatus: 'active' as const,
+    displayStatus: 'active',
     tfManaged: false,
   };
 
   it('renders the node label', () => {
-    render(<InternetGatewayNode {...createNodeProps(defaultIGWData)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
     expect(screen.getByText('main-igw')).toBeInTheDocument();
   });
 
   it('renders the IGW ID', () => {
-    render(<InternetGatewayNode {...createNodeProps(defaultIGWData)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
     expect(screen.getByText('igw-12345')).toBeInTheDocument();
   });
 
   it('renders default label when no label provided', () => {
     const data = { ...defaultIGWData, label: '' };
-    render(<InternetGatewayNode {...createNodeProps(data)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
     expect(screen.getByText('IGW')).toBeInTheDocument();
   });
 
   it('renders TF badge when terraform managed', () => {
     const data = { ...defaultIGWData, tfManaged: true };
-    render(<InternetGatewayNode {...createNodeProps(data)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
     expect(screen.getByText('TF')).toBeInTheDocument();
   });
 
   it('does not render TF badge when not terraform managed', () => {
-    render(<InternetGatewayNode {...createNodeProps(defaultIGWData)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
     expect(screen.queryByText('TF')).not.toBeInTheDocument();
   });
 
   it('renders with active status styling', () => {
-    const { container } = render(<InternetGatewayNode {...createNodeProps(defaultIGWData)} />);
+    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-green-500');
   });
 
   it('renders with inactive status styling', () => {
     const data = { ...defaultIGWData, displayStatus: 'inactive' as const };
-    const { container } = render(<InternetGatewayNode {...createNodeProps(data)} />);
+    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-gray-400');
   });
 
   it('renders with transitioning status styling', () => {
     const data = { ...defaultIGWData, displayStatus: 'transitioning' as const };
-    const { container } = render(<InternetGatewayNode {...createNodeProps(data)} />);
+    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-yellow-500');
   });
 
   it('renders with error status styling', () => {
     const data = { ...defaultIGWData, displayStatus: 'error' as const };
-    const { container } = render(<InternetGatewayNode {...createNodeProps(data)} />);
+    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-red-500');
   });
 
   it('renders handles for connections', () => {
-    render(<InternetGatewayNode {...createNodeProps(defaultIGWData)} />);
+    render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
     expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
     expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
   });
 });
 
 describe('NATGatewayNode', () => {
-  const defaultNATData = {
+  const defaultNATData: NATGatewayNodeData = {
+    type: 'nat-gateway',
     label: 'nat-gw-1',
-    displayStatus: 'active' as const,
+    natGatewayId: 'nat-12345',
+    displayStatus: 'active',
     publicIp: '54.1.2.3',
     tfManaged: false,
   };
 
   it('renders the node label', () => {
-    render(<NATGatewayNode {...createNodeProps(defaultNATData)} />);
+    render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
     expect(screen.getByText('nat-gw-1')).toBeInTheDocument();
   });
 
   it('renders the public IP when provided', () => {
-    render(<NATGatewayNode {...createNodeProps(defaultNATData)} />);
+    render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
     expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
   });
 
   it('does not render public IP when not provided', () => {
     const data = { ...defaultNATData, publicIp: undefined };
-    render(<NATGatewayNode {...createNodeProps(data)} />);
+    render(<NATGatewayNode {...createNATNodeProps(data)} />);
     expect(screen.queryByText('54.1.2.3')).not.toBeInTheDocument();
   });
 
   it('renders default label when no label provided', () => {
     const data = { ...defaultNATData, label: '' };
-    render(<NATGatewayNode {...createNodeProps(data)} />);
+    render(<NATGatewayNode {...createNATNodeProps(data)} />);
     expect(screen.getByText('NAT')).toBeInTheDocument();
   });
 
   it('renders TF badge when terraform managed', () => {
     const data = { ...defaultNATData, tfManaged: true };
-    render(<NATGatewayNode {...createNodeProps(data)} />);
+    render(<NATGatewayNode {...createNATNodeProps(data)} />);
     expect(screen.getByText('TF')).toBeInTheDocument();
   });
 
   it('does not render TF badge when not terraform managed', () => {
-    render(<NATGatewayNode {...createNodeProps(defaultNATData)} />);
+    render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
     expect(screen.queryByText('TF')).not.toBeInTheDocument();
   });
 
   it('renders with active status styling', () => {
-    const { container } = render(<NATGatewayNode {...createNodeProps(defaultNATData)} />);
+    const { container } = render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-green-500');
   });
 
   it('renders with inactive status styling', () => {
     const data = { ...defaultNATData, displayStatus: 'inactive' as const };
-    const { container } = render(<NATGatewayNode {...createNodeProps(data)} />);
+    const { container } = render(<NATGatewayNode {...createNATNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
     expect(nodeDiv.className).toContain('border-gray-400');
   });
 
   it('renders handles for connections', () => {
-    render(<NATGatewayNode {...createNodeProps(defaultNATData)} />);
+    render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
     expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
     expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
   });

--- a/frontend/src/components/topology/nodes/RDSNode.test.tsx
+++ b/frontend/src/components/topology/nodes/RDSNode.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/test-utils';
 import { RDSNode } from './RDSNode';
+import type { RDSNodeData } from '@/types/topology';
 
 // Mock react-flow
 vi.mock('reactflow', () => ({
@@ -15,24 +16,29 @@ vi.mock('reactflow', () => ({
   },
 }));
 
-const defaultData = {
+const defaultData: RDSNodeData = {
+  type: 'rds',
   label: 'prod-database',
+  dbIdentifier: 'prod-db-01',
   engine: 'mysql 8.0',
   instanceClass: 'db.t3.micro',
-  displayStatus: 'active' as const,
+  displayStatus: 'active',
+  status: 'available',
   tfManaged: false,
 };
 
-const createNodeProps = (data: typeof defaultData) => ({
+const createNodeProps = (data: RDSNodeData) => ({
   id: 'test-node',
   data,
-  type: 'rdsNode',
+  type: 'rds',
   selected: false,
   isConnectable: true,
   xPos: 0,
   yPos: 0,
   zIndex: 1,
   dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe('RDSNode', () => {

--- a/frontend/src/components/topology/nodes/SubnetNode.test.tsx
+++ b/frontend/src/components/topology/nodes/SubnetNode.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/test-utils';
 import { SubnetNode } from './SubnetNode';
+import type { SubnetNodeData } from '@/types/topology';
 
 // Mock react-flow
 vi.mock('reactflow', () => ({
@@ -15,24 +16,29 @@ vi.mock('reactflow', () => ({
   },
 }));
 
-const defaultData = {
+const defaultData: SubnetNodeData = {
+  type: 'subnet',
   label: 'public-subnet-1',
-  subnetType: 'public' as const,
+  subnetId: 'subnet-12345',
+  subnetType: 'public',
   cidrBlock: '10.0.1.0/24',
   availabilityZone: 'us-east-1a',
+  displayStatus: 'active',
   tfManaged: false,
 };
 
-const createNodeProps = (data: typeof defaultData) => ({
+const createNodeProps = (data: SubnetNodeData) => ({
   id: 'test-node',
   data,
-  type: 'subnetNode',
+  type: 'subnet',
   selected: false,
   isConnectable: true,
   xPos: 0,
   yPos: 0,
   zIndex: 1,
   dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe('SubnetNode', () => {

--- a/frontend/src/components/topology/nodes/VPCNode.test.tsx
+++ b/frontend/src/components/topology/nodes/VPCNode.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@/test/test-utils';
 import { VPCNode } from './VPCNode';
+import type { VPCNodeData } from '@/types/topology';
 
 // Mock react-flow
 vi.mock('reactflow', () => ({
@@ -15,24 +16,27 @@ vi.mock('reactflow', () => ({
   },
 }));
 
-const defaultData = {
+const defaultData: VPCNodeData = {
+  type: 'vpc',
   label: 'main-vpc',
   vpcId: 'vpc-12345',
   cidrBlock: '10.0.0.0/16',
-  displayStatus: 'active' as const,
+  displayStatus: 'active',
   tfManaged: false,
 };
 
-const createNodeProps = (data: typeof defaultData) => ({
+const createNodeProps = (data: VPCNodeData) => ({
   id: 'test-node',
   data,
-  type: 'vpcNode',
+  type: 'vpc',
   selected: false,
   isConnectable: true,
   xPos: 0,
   yPos: 0,
   zIndex: 1,
   dragging: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
 });
 
 describe('VPCNode', () => {

--- a/frontend/src/components/vpc/ElasticIPDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/ElasticIPDetailPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { ElasticIPDetailPanel } from './ElasticIPDetailPanel';
 
 const mockElasticIP = {
+  id: 1,
   allocation_id: 'eipalloc-123456',
   name: 'Web Server EIP',
   public_ip: '54.1.2.3',
@@ -18,6 +19,8 @@ const mockElasticIP = {
   tf_resource_address: 'aws_eip.web',
   updated_at: '2024-01-15T12:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
   tags: { Environment: 'production' },
 };
 

--- a/frontend/src/components/vpc/IGWDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/IGWDetailPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { IGWDetailPanel } from './IGWDetailPanel';
 
 const mockIGW = {
+  id: 1,
   igw_id: 'igw-123456',
   name: 'Main IGW',
   vpc_id: 'vpc-123',
@@ -14,6 +15,8 @@ const mockIGW = {
   tf_resource_address: 'aws_internet_gateway.main',
   updated_at: '2024-01-15T12:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
   tags: { Environment: 'production' },
 };
 

--- a/frontend/src/components/vpc/NATGatewayDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/NATGatewayDetailPanel.test.tsx
@@ -3,13 +3,14 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { NATGatewayDetailPanel } from './NATGatewayDetailPanel';
 
 const mockNATGateway = {
+  id: 1,
   nat_gateway_id: 'nat-123456',
   name: 'NAT Gateway 1',
   vpc_id: 'vpc-123',
   subnet_id: 'subnet-123',
   display_status: 'active' as const,
   state: 'available',
-  connectivity_type: 'public',
+  connectivity_type: 'public' as const,
   primary_public_ip: '54.1.2.3',
   primary_private_ip: '10.0.1.100',
   allocation_id: 'eipalloc-123',
@@ -20,6 +21,8 @@ const mockNATGateway = {
   tf_resource_address: 'aws_nat_gateway.main',
   updated_at: '2024-01-15T12:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
   tags: { Environment: 'production' },
 };
 

--- a/frontend/src/components/vpc/SubnetDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/SubnetDetailPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { SubnetDetailPanel } from './SubnetDetailPanel';
 
 const mockSubnet = {
+  id: 1,
   subnet_id: 'subnet-123456',
   vpc_id: 'vpc-123',
   name: 'Public Subnet 1',
@@ -14,12 +15,13 @@ const mockSubnet = {
   region_name: 'us-east-1',
   available_ip_count: 251,
   map_public_ip_on_launch: true,
-  default_for_az: false,
   tf_managed: true,
   tf_state_source: 'prod/terraform.tfstate',
   tf_resource_address: 'aws_subnet.public',
   updated_at: '2024-01-15T12:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  deleted_at: null,
   tags: { Environment: 'production' },
 };
 

--- a/frontend/src/components/vpc/VPCDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/VPCDetailPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { VPCDetailPanel } from './VPCDetailPanel';
 
 const mockVPC = {
+  id: 1,
   vpc_id: 'vpc-123456',
   name: 'Production VPC',
   cidr_block: '10.0.0.0/16',
@@ -17,7 +18,8 @@ const mockVPC = {
   tf_resource_address: 'aws_vpc.main',
   updated_at: '2024-01-15T12:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
-  instance_tenancy: 'default',
+  is_deleted: false,
+  deleted_at: null,
   tags: { Environment: 'production', Project: 'main' },
 };
 

--- a/frontend/src/components/vpc/VPCTabNavigation.test.tsx
+++ b/frontend/src/components/vpc/VPCTabNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@/test/test-utils';
 import { VPCTabNavigation } from './VPCTabNavigation';
 


### PR DESCRIPTION
- Add nosec B104 comment to backend config.py for intentional 0.0.0.0 bind
- Fix missing vitest imports (beforeEach, afterEach) in test files
- Add missing id, is_deleted, deleted_at fields to mock data in tests
- Fix TopologyResponse type compliance in TopologyCanvas tests
- Fix topology node test data to match required types
- Update useResources tests with proper ListResponse structure

All 630 tests pass and build completes successfully.

https://claude.ai/code/session_01ERhc66wf4pSUzaX6pfsT55