### PR TITLE
Format frontend code and remove ESLint flat config flag

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
-        env:
-          ESLINT_USE_FLAT_CONFIG: false
 
       - name: Check code formatting with Prettier
         run: npx prettier --check "src/**/*.{ts,tsx,css}"

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,22 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
 // Mock all pages to simplify testing
-vi.mock('@/pages', () => ({
-  DashboardPage: () => <div data-testid="dashboard-page">Dashboard Content</div>,
+vi.mock("@/pages", () => ({
+  DashboardPage: () => (
+    <div data-testid="dashboard-page">Dashboard Content</div>
+  ),
   EC2ListPage: () => <div data-testid="ec2-page">EC2 Content</div>,
   RDSListPage: () => <div data-testid="rds-page">RDS Content</div>,
   VPCPage: () => <div data-testid="vpc-page">VPC Content</div>,
-  TerraformPage: () => <div data-testid="terraform-page">Terraform Content</div>,
+  TerraformPage: () => (
+    <div data-testid="terraform-page">Terraform Content</div>
+  ),
   TopologyPage: () => <div data-testid="topology-page">Topology Content</div>,
 }));
 
 // Mock the hooks used by Layout components
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useStatusSummary: () => ({
     data: {
-      last_refreshed: '2024-01-15T12:00:00Z',
+      last_refreshed: "2024-01-15T12:00:00Z",
       total_resources: 10,
     },
   }),
@@ -26,46 +30,48 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('App', () => {
-  it('renders without crashing', () => {
+describe("App", () => {
+  it("renders without crashing", () => {
     render(<App />);
     expect(document.body).toBeInTheDocument();
   });
 
-  it('renders the header with application title', () => {
+  it("renders the header with application title", () => {
     render(<App />);
-    expect(screen.getByText('AWS Infrastructure Visualizer')).toBeInTheDocument();
+    expect(
+      screen.getByText("AWS Infrastructure Visualizer"),
+    ).toBeInTheDocument();
   });
 
-  it('renders the sidebar navigation', () => {
+  it("renders the sidebar navigation", () => {
     render(<App />);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('EC2 Instances')).toBeInTheDocument();
-    expect(screen.getByText('RDS Databases')).toBeInTheDocument();
-    expect(screen.getByText('VPC Networking')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instances")).toBeInTheDocument();
+    expect(screen.getByText("RDS Databases")).toBeInTheDocument();
+    expect(screen.getByText("VPC Networking")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('renders Dashboard page at root route', () => {
+  it("renders Dashboard page at root route", () => {
     render(<App />);
-    expect(screen.getByTestId('dashboard-page')).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
   });
 
-  it('renders main content area', () => {
+  it("renders main content area", () => {
     render(<App />);
-    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 
-  it('renders header with refresh button', () => {
+  it("renders header with refresh button", () => {
     render(<App />);
-    expect(screen.getByText('Refresh')).toBeInTheDocument();
+    expect(screen.getByText("Refresh")).toBeInTheDocument();
   });
 });
 
-describe('SettingsPlaceholder', () => {
-  it('is accessible via navigation', () => {
+describe("SettingsPlaceholder", () => {
+  it("is accessible via navigation", () => {
     render(<App />);
     // Settings link should be present in sidebar
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import axios from 'axios';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
 import {
   getHealthStatus,
   getStatusSummary,
@@ -21,7 +21,7 @@ import {
   getTerraformStates,
   getDrift,
   getTopology,
-} from './client';
+} from "./client";
 
 // Mock axios - type assertion for self-reference
 interface MockAxiosInstance {
@@ -34,7 +34,7 @@ interface MockAxiosInstance {
   };
 }
 
-vi.mock('axios', () => {
+vi.mock("axios", () => {
   const mockAxios: MockAxiosInstance = {
     create: vi.fn(),
     get: vi.fn(),
@@ -54,367 +54,399 @@ const mockedAxios = axios as unknown as {
   post: ReturnType<typeof vi.fn>;
 };
 
-describe('API Client', () => {
+describe("API Client", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('getHealthStatus', () => {
-    it('fetches health status', async () => {
-      const mockResponse = { data: { status: 'healthy', timestamp: '2024-01-15T12:00:00Z' } };
+  describe("getHealthStatus", () => {
+    it("fetches health status", async () => {
+      const mockResponse = {
+        data: { status: "healthy", timestamp: "2024-01-15T12:00:00Z" },
+      };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getHealthStatus();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/health');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/health");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getStatusSummary', () => {
-    it('fetches status summary', async () => {
+  describe("getStatusSummary", () => {
+    it("fetches status summary", async () => {
       const mockResponse = {
         data: {
           total_resources: 10,
-          last_refreshed: '2024-01-15T12:00:00Z',
+          last_refreshed: "2024-01-15T12:00:00Z",
         },
       };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getStatusSummary();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/status/summary');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/status/summary");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getEC2Instances', () => {
-    it('fetches EC2 instances without filters', async () => {
+  describe("getEC2Instances", () => {
+    it("fetches EC2 instances without filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getEC2Instances();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/ec2', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/ec2", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches EC2 instances with status filter', async () => {
+    it("fetches EC2 instances with status filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getEC2Instances({ status: 'active' });
+      await getEC2Instances({ status: "active" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('status')).toBe('active');
+      expect(call[1].params.get("status")).toBe("active");
     });
 
-    it('fetches EC2 instances with search filter', async () => {
+    it("fetches EC2 instances with search filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getEC2Instances({ search: 'web-server' });
+      await getEC2Instances({ search: "web-server" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('search')).toBe('web-server');
+      expect(call[1].params.get("search")).toBe("web-server");
     });
 
-    it('fetches EC2 instances with tf_managed filter', async () => {
+    it("fetches EC2 instances with tf_managed filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       await getEC2Instances({ tf_managed: true });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('tf_managed')).toBe('true');
+      expect(call[1].params.get("tf_managed")).toBe("true");
     });
   });
 
-  describe('getEC2Instance', () => {
-    it('fetches single EC2 instance', async () => {
-      const mockResponse = { data: { instance_id: 'i-123', name: 'Test' } };
+  describe("getEC2Instance", () => {
+    it("fetches single EC2 instance", async () => {
+      const mockResponse = { data: { instance_id: "i-123", name: "Test" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getEC2Instance('i-123');
+      const result = await getEC2Instance("i-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/ec2/i-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/ec2/i-123");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getRDSInstances', () => {
-    it('fetches RDS instances without filters', async () => {
+  describe("getRDSInstances", () => {
+    it("fetches RDS instances without filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getRDSInstances();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/rds', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/rds", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches RDS instances with filters', async () => {
+    it("fetches RDS instances with filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getRDSInstances({ status: 'active', region: 'us-east-1' });
+      await getRDSInstances({ status: "active", region: "us-east-1" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('status')).toBe('active');
-      expect(call[1].params.get('region')).toBe('us-east-1');
+      expect(call[1].params.get("status")).toBe("active");
+      expect(call[1].params.get("region")).toBe("us-east-1");
     });
   });
 
-  describe('getRDSInstance', () => {
-    it('fetches single RDS instance', async () => {
-      const mockResponse = { data: { db_instance_identifier: 'prod-db', name: 'Test' } };
+  describe("getRDSInstance", () => {
+    it("fetches single RDS instance", async () => {
+      const mockResponse = {
+        data: { db_instance_identifier: "prod-db", name: "Test" },
+      };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getRDSInstance('prod-db');
+      const result = await getRDSInstance("prod-db");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/rds/prod-db');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/rds/prod-db");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getVPCs', () => {
-    it('fetches VPCs without filters', async () => {
+  describe("getVPCs", () => {
+    it("fetches VPCs without filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getVPCs();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/vpcs', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/vpcs", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getVPC', () => {
-    it('fetches single VPC', async () => {
-      const mockResponse = { data: { vpc_id: 'vpc-123', name: 'Test' } };
+  describe("getVPC", () => {
+    it("fetches single VPC", async () => {
+      const mockResponse = { data: { vpc_id: "vpc-123", name: "Test" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getVPC('vpc-123');
+      const result = await getVPC("vpc-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/vpcs/vpc-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/vpcs/vpc-123");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getSubnets', () => {
-    it('fetches subnets without filters', async () => {
+  describe("getSubnets", () => {
+    it("fetches subnets without filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getSubnets();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/subnets', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/subnets", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches subnets with vpc_id filter', async () => {
+    it("fetches subnets with vpc_id filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getSubnets({ vpc_id: 'vpc-123' });
+      await getSubnets({ vpc_id: "vpc-123" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('vpc_id')).toBe('vpc-123');
+      expect(call[1].params.get("vpc_id")).toBe("vpc-123");
     });
 
-    it('fetches subnets with subnet_type filter', async () => {
+    it("fetches subnets with subnet_type filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getSubnets({ subnet_type: 'public' });
+      await getSubnets({ subnet_type: "public" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('subnet_type')).toBe('public');
+      expect(call[1].params.get("subnet_type")).toBe("public");
     });
   });
 
-  describe('getSubnet', () => {
-    it('fetches single subnet', async () => {
-      const mockResponse = { data: { subnet_id: 'subnet-123', name: 'Test' } };
+  describe("getSubnet", () => {
+    it("fetches single subnet", async () => {
+      const mockResponse = { data: { subnet_id: "subnet-123", name: "Test" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getSubnet('subnet-123');
+      const result = await getSubnet("subnet-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/subnets/subnet-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/subnets/subnet-123");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getInternetGateways', () => {
-    it('fetches internet gateways', async () => {
+  describe("getInternetGateways", () => {
+    it("fetches internet gateways", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getInternetGateways();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/internet-gateways', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/internet-gateways", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches internet gateways with vpc_id filter', async () => {
+    it("fetches internet gateways with vpc_id filter", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getInternetGateways({ vpc_id: 'vpc-123' });
+      await getInternetGateways({ vpc_id: "vpc-123" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('vpc_id')).toBe('vpc-123');
+      expect(call[1].params.get("vpc_id")).toBe("vpc-123");
     });
   });
 
-  describe('getInternetGateway', () => {
-    it('fetches single internet gateway', async () => {
-      const mockResponse = { data: { igw_id: 'igw-123' } };
+  describe("getInternetGateway", () => {
+    it("fetches single internet gateway", async () => {
+      const mockResponse = { data: { igw_id: "igw-123" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getInternetGateway('igw-123');
+      const result = await getInternetGateway("igw-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/internet-gateways/igw-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        "/internet-gateways/igw-123",
+      );
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getNATGateways', () => {
-    it('fetches NAT gateways', async () => {
+  describe("getNATGateways", () => {
+    it("fetches NAT gateways", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getNATGateways();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/nat-gateways', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/nat-gateways", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches NAT gateways with filters', async () => {
+    it("fetches NAT gateways with filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getNATGateways({ vpc_id: 'vpc-123', subnet_id: 'subnet-456', connectivity_type: 'public' });
+      await getNATGateways({
+        vpc_id: "vpc-123",
+        subnet_id: "subnet-456",
+        connectivity_type: "public",
+      });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('vpc_id')).toBe('vpc-123');
-      expect(call[1].params.get('subnet_id')).toBe('subnet-456');
-      expect(call[1].params.get('connectivity_type')).toBe('public');
+      expect(call[1].params.get("vpc_id")).toBe("vpc-123");
+      expect(call[1].params.get("subnet_id")).toBe("subnet-456");
+      expect(call[1].params.get("connectivity_type")).toBe("public");
     });
   });
 
-  describe('getNATGateway', () => {
-    it('fetches single NAT gateway', async () => {
-      const mockResponse = { data: { nat_gateway_id: 'nat-123' } };
+  describe("getNATGateway", () => {
+    it("fetches single NAT gateway", async () => {
+      const mockResponse = { data: { nat_gateway_id: "nat-123" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getNATGateway('nat-123');
+      const result = await getNATGateway("nat-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/nat-gateways/nat-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/nat-gateways/nat-123");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getElasticIPs', () => {
-    it('fetches elastic IPs', async () => {
+  describe("getElasticIPs", () => {
+    it("fetches elastic IPs", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getElasticIPs();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/elastic-ips', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/elastic-ips", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches elastic IPs with filters', async () => {
+    it("fetches elastic IPs with filters", async () => {
       const mockResponse = { data: { items: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getElasticIPs({ instance_id: 'i-123', associated: true });
+      await getElasticIPs({ instance_id: "i-123", associated: true });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('instance_id')).toBe('i-123');
-      expect(call[1].params.get('associated')).toBe('true');
+      expect(call[1].params.get("instance_id")).toBe("i-123");
+      expect(call[1].params.get("associated")).toBe("true");
     });
   });
 
-  describe('getElasticIP', () => {
-    it('fetches single elastic IP', async () => {
-      const mockResponse = { data: { allocation_id: 'eipalloc-123' } };
+  describe("getElasticIP", () => {
+    it("fetches single elastic IP", async () => {
+      const mockResponse = { data: { allocation_id: "eipalloc-123" } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      const result = await getElasticIP('eipalloc-123');
+      const result = await getElasticIP("eipalloc-123");
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/elastic-ips/eipalloc-123');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/elastic-ips/eipalloc-123");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('refreshData', () => {
-    it('refreshes data without force', async () => {
-      const mockResponse = { data: { success: true, message: 'Refreshed' } };
+  describe("refreshData", () => {
+    it("refreshes data without force", async () => {
+      const mockResponse = { data: { success: true, message: "Refreshed" } };
       mockedAxios.post.mockResolvedValue(mockResponse);
 
       const result = await refreshData();
 
-      expect(mockedAxios.post).toHaveBeenCalledWith('/refresh', { force: false });
+      expect(mockedAxios.post).toHaveBeenCalledWith("/refresh", {
+        force: false,
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('refreshes data with force', async () => {
-      const mockResponse = { data: { success: true, message: 'Force refreshed' } };
+    it("refreshes data with force", async () => {
+      const mockResponse = {
+        data: { success: true, message: "Force refreshed" },
+      };
       mockedAxios.post.mockResolvedValue(mockResponse);
 
       const result = await refreshData(true);
 
-      expect(mockedAxios.post).toHaveBeenCalledWith('/refresh', { force: true });
+      expect(mockedAxios.post).toHaveBeenCalledWith("/refresh", {
+        force: true,
+      });
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getTerraformStates', () => {
-    it('fetches terraform states', async () => {
+  describe("getTerraformStates", () => {
+    it("fetches terraform states", async () => {
       const mockResponse = { data: { states: [], total: 0 } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getTerraformStates();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/terraform/states');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/terraform/states");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getDrift', () => {
-    it('fetches drift data', async () => {
+  describe("getDrift", () => {
+    it("fetches drift data", async () => {
       const mockResponse = { data: { has_drift: false, drifts: [] } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getDrift();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/terraform/drift');
+      expect(mockedAxios.get).toHaveBeenCalledWith("/terraform/drift");
       expect(result).toEqual(mockResponse.data);
     });
   });
 
-  describe('getTopology', () => {
-    it('fetches topology without filters', async () => {
+  describe("getTopology", () => {
+    it("fetches topology without filters", async () => {
       const mockResponse = { data: { nodes: [], edges: [] } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
       const result = await getTopology();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/topology', { params: expect.any(URLSearchParams) });
+      expect(mockedAxios.get).toHaveBeenCalledWith("/topology", {
+        params: expect.any(URLSearchParams),
+      });
       expect(result).toEqual(mockResponse.data);
     });
 
-    it('fetches topology with vpc_id filter', async () => {
+    it("fetches topology with vpc_id filter", async () => {
       const mockResponse = { data: { nodes: [], edges: [] } };
       mockedAxios.get.mockResolvedValue(mockResponse);
 
-      await getTopology({ vpc_id: 'vpc-123' });
+      await getTopology({ vpc_id: "vpc-123" });
 
       const call = mockedAxios.get.mock.calls[0];
-      expect(call[1].params.get('vpc_id')).toBe('vpc-123');
+      expect(call[1].params.get("vpc_id")).toBe("vpc-123");
     });
   });
 });

--- a/frontend/src/components/common/Button.test.tsx
+++ b/frontend/src/components/common/Button.test.tsx
@@ -1,92 +1,94 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { Button } from './Button';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { Button } from "./Button";
 
-describe('Button', () => {
-  it('renders children correctly', () => {
+describe("Button", () => {
+  it("renders children correctly", () => {
     render(<Button>Click me</Button>);
-    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /click me/i }),
+    ).toBeInTheDocument();
   });
 
-  it('handles click events', () => {
+  it("handles click events", () => {
     const handleClick = vi.fn();
     render(<Button onClick={handleClick}>Click me</Button>);
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole("button"));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it('applies primary variant styles by default', () => {
+  it("applies primary variant styles by default", () => {
     render(<Button>Primary</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-blue-600');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("bg-blue-600");
   });
 
-  it('applies secondary variant styles', () => {
+  it("applies secondary variant styles", () => {
     render(<Button variant="secondary">Secondary</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-gray-100');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("bg-gray-100");
   });
 
-  it('applies outline variant styles', () => {
+  it("applies outline variant styles", () => {
     render(<Button variant="outline">Outline</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('border');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("border");
   });
 
-  it('applies ghost variant styles', () => {
+  it("applies ghost variant styles", () => {
     render(<Button variant="ghost">Ghost</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('text-gray-600');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("text-gray-600");
   });
 
-  it('applies danger variant styles', () => {
+  it("applies danger variant styles", () => {
     render(<Button variant="danger">Danger</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-red-600');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("bg-red-600");
   });
 
-  it('applies small size styles', () => {
+  it("applies small size styles", () => {
     render(<Button size="sm">Small</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('px-3', 'py-1.5');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("px-3", "py-1.5");
   });
 
-  it('applies medium size styles by default', () => {
+  it("applies medium size styles by default", () => {
     render(<Button>Medium</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('px-4', 'py-2');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("px-4", "py-2");
   });
 
-  it('applies large size styles', () => {
+  it("applies large size styles", () => {
     render(<Button size="lg">Large</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('px-6', 'py-3');
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("px-6", "py-3");
   });
 
-  it('disables button when disabled prop is true', () => {
+  it("disables button when disabled prop is true", () => {
     render(<Button disabled>Disabled</Button>);
-    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it('disables button when loading prop is true', () => {
+  it("disables button when loading prop is true", () => {
     render(<Button loading>Loading</Button>);
-    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it('shows loading spinner when loading', () => {
+  it("shows loading spinner when loading", () => {
     render(<Button loading>Loading</Button>);
-    const button = screen.getByRole('button');
-    expect(button.querySelector('.animate-spin')).toBeInTheDocument();
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('renders with icon', () => {
+  it("renders with icon", () => {
     const Icon = () => <span data-testid="icon">Icon</span>;
     render(<Button icon={<Icon />}>With Icon</Button>);
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
-  it('applies custom className', () => {
+  it("applies custom className", () => {
     render(<Button className="custom-class">Custom</Button>);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    expect(screen.getByRole("button")).toHaveClass("custom-class");
   });
 });

--- a/frontend/src/components/common/Card.test.tsx
+++ b/frontend/src/components/common/Card.test.tsx
@@ -1,119 +1,125 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { Card, CardHeader, CardTitle, CardContent } from './Card';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { Card, CardHeader, CardTitle, CardContent } from "./Card";
 
-describe('Card', () => {
-  it('renders children correctly', () => {
+describe("Card", () => {
+  it("renders children correctly", () => {
     render(<Card>Card content</Card>);
-    expect(screen.getByText('Card content')).toBeInTheDocument();
+    expect(screen.getByText("Card content")).toBeInTheDocument();
   });
 
-  it('applies base styles', () => {
+  it("applies base styles", () => {
     const { container } = render(<Card>Content</Card>);
     const card = container.firstChild;
-    expect(card).toHaveClass('rounded-lg', 'border', 'bg-white', 'shadow-sm');
+    expect(card).toHaveClass("rounded-lg", "border", "bg-white", "shadow-sm");
   });
 
-  it('handles click events', () => {
+  it("handles click events", () => {
     const handleClick = vi.fn();
     render(<Card onClick={handleClick}>Clickable</Card>);
-    fireEvent.click(screen.getByText('Clickable'));
+    fireEvent.click(screen.getByText("Clickable"));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it('applies hover styles when hover prop is true', () => {
+  it("applies hover styles when hover prop is true", () => {
     const { container } = render(<Card hover>Hoverable</Card>);
     const card = container.firstChild;
-    expect(card).toHaveClass('hover:shadow-md');
+    expect(card).toHaveClass("hover:shadow-md");
   });
 
-  it('applies cursor-pointer when onClick is provided', () => {
+  it("applies cursor-pointer when onClick is provided", () => {
     const { container } = render(<Card onClick={() => {}}>Clickable</Card>);
     const card = container.firstChild;
-    expect(card).toHaveClass('cursor-pointer');
+    expect(card).toHaveClass("cursor-pointer");
   });
 
-  it('applies custom className', () => {
+  it("applies custom className", () => {
     const { container } = render(<Card className="custom-class">Content</Card>);
     const card = container.firstChild;
-    expect(card).toHaveClass('custom-class');
+    expect(card).toHaveClass("custom-class");
   });
 });
 
-describe('CardHeader', () => {
-  it('renders children correctly', () => {
+describe("CardHeader", () => {
+  it("renders children correctly", () => {
     render(<CardHeader>Header content</CardHeader>);
-    expect(screen.getByText('Header content')).toBeInTheDocument();
+    expect(screen.getByText("Header content")).toBeInTheDocument();
   });
 
-  it('applies border styles', () => {
+  it("applies border styles", () => {
     const { container } = render(<CardHeader>Header</CardHeader>);
     const header = container.firstChild;
-    expect(header).toHaveClass('border-b', 'px-4', 'py-3');
+    expect(header).toHaveClass("border-b", "px-4", "py-3");
   });
 
-  it('applies custom className', () => {
-    const { container } = render(<CardHeader className="custom-class">Header</CardHeader>);
+  it("applies custom className", () => {
+    const { container } = render(
+      <CardHeader className="custom-class">Header</CardHeader>,
+    );
     const header = container.firstChild;
-    expect(header).toHaveClass('custom-class');
+    expect(header).toHaveClass("custom-class");
   });
 });
 
-describe('CardTitle', () => {
-  it('renders children correctly', () => {
+describe("CardTitle", () => {
+  it("renders children correctly", () => {
     render(<CardTitle>Title text</CardTitle>);
-    expect(screen.getByText('Title text')).toBeInTheDocument();
+    expect(screen.getByText("Title text")).toBeInTheDocument();
   });
 
-  it('renders as h3 element', () => {
+  it("renders as h3 element", () => {
     render(<CardTitle>Title</CardTitle>);
-    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3 })).toBeInTheDocument();
   });
 
-  it('applies text styles', () => {
+  it("applies text styles", () => {
     const { container } = render(<CardTitle>Title</CardTitle>);
     const title = container.firstChild;
-    expect(title).toHaveClass('text-lg', 'font-semibold');
+    expect(title).toHaveClass("text-lg", "font-semibold");
   });
 
-  it('applies custom className', () => {
-    const { container } = render(<CardTitle className="custom-class">Title</CardTitle>);
+  it("applies custom className", () => {
+    const { container } = render(
+      <CardTitle className="custom-class">Title</CardTitle>,
+    );
     const title = container.firstChild;
-    expect(title).toHaveClass('custom-class');
+    expect(title).toHaveClass("custom-class");
   });
 });
 
-describe('CardContent', () => {
-  it('renders children correctly', () => {
+describe("CardContent", () => {
+  it("renders children correctly", () => {
     render(<CardContent>Content text</CardContent>);
-    expect(screen.getByText('Content text')).toBeInTheDocument();
+    expect(screen.getByText("Content text")).toBeInTheDocument();
   });
 
-  it('applies padding styles', () => {
+  it("applies padding styles", () => {
     const { container } = render(<CardContent>Content</CardContent>);
     const content = container.firstChild;
-    expect(content).toHaveClass('p-4');
+    expect(content).toHaveClass("p-4");
   });
 
-  it('applies custom className', () => {
-    const { container } = render(<CardContent className="custom-class">Content</CardContent>);
+  it("applies custom className", () => {
+    const { container } = render(
+      <CardContent className="custom-class">Content</CardContent>,
+    );
     const content = container.firstChild;
-    expect(content).toHaveClass('custom-class');
+    expect(content).toHaveClass("custom-class");
   });
 });
 
-describe('Card composition', () => {
-  it('renders full card with all components', () => {
+describe("Card composition", () => {
+  it("renders full card with all components", () => {
     render(
       <Card>
         <CardHeader>
           <CardTitle>Test Title</CardTitle>
         </CardHeader>
         <CardContent>Test content</CardContent>
-      </Card>
+      </Card>,
     );
 
-    expect(screen.getByText('Test Title')).toBeInTheDocument();
-    expect(screen.getByText('Test content')).toBeInTheDocument();
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Test content")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/EmptyState.test.tsx
+++ b/frontend/src/components/common/EmptyState.test.tsx
@@ -1,67 +1,74 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { EmptyState } from './EmptyState';
-import { Button } from './Button';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { EmptyState } from "./EmptyState";
+import { Button } from "./Button";
 
-describe('EmptyState', () => {
-  it('renders title correctly', () => {
+describe("EmptyState", () => {
+  it("renders title correctly", () => {
     render(<EmptyState title="No data found" />);
-    expect(screen.getByText('No data found')).toBeInTheDocument();
+    expect(screen.getByText("No data found")).toBeInTheDocument();
   });
 
-  it('renders title as heading', () => {
+  it("renders title as heading", () => {
     render(<EmptyState title="No data found" />);
-    expect(screen.getByRole('heading', { name: /no data found/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /no data found/i }),
+    ).toBeInTheDocument();
   });
 
-  it('renders description when provided', () => {
+  it("renders description when provided", () => {
     render(<EmptyState title="No data" description="Please add some items" />);
-    expect(screen.getByText('Please add some items')).toBeInTheDocument();
+    expect(screen.getByText("Please add some items")).toBeInTheDocument();
   });
 
-  it('does not render description when not provided', () => {
+  it("does not render description when not provided", () => {
     render(<EmptyState title="No data" />);
-    expect(screen.queryByText('Please add some items')).not.toBeInTheDocument();
+    expect(screen.queryByText("Please add some items")).not.toBeInTheDocument();
   });
 
-  it('renders default icon when none provided', () => {
+  it("renders default icon when none provided", () => {
     const { container } = render(<EmptyState title="No data" />);
     // Should have the InboxIcon SVG
-    const iconContainer = container.querySelector('.rounded-full.bg-gray-100');
+    const iconContainer = container.querySelector(".rounded-full.bg-gray-100");
     expect(iconContainer).toBeInTheDocument();
   });
 
-  it('renders custom icon when provided', () => {
+  it("renders custom icon when provided", () => {
     const CustomIcon = () => <span data-testid="custom-icon">Custom</span>;
     render(<EmptyState title="No data" icon={<CustomIcon />} />);
-    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
   });
 
-  it('renders action when provided', () => {
-    render(
-      <EmptyState
-        title="No data"
-        action={<Button>Add Item</Button>}
-      />
+  it("renders action when provided", () => {
+    render(<EmptyState title="No data" action={<Button>Add Item</Button>} />);
+    expect(
+      screen.getByRole("button", { name: /add item/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies dashed border styles", () => {
+    const { container } = render(<EmptyState title="No data" />);
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("border-dashed", "border-2");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <EmptyState title="No data" className="custom-class" />,
     );
-    expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("custom-class");
   });
 
-  it('applies dashed border styles', () => {
+  it("centers content", () => {
     const { container } = render(<EmptyState title="No data" />);
     const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('border-dashed', 'border-2');
-  });
-
-  it('applies custom className', () => {
-    const { container } = render(<EmptyState title="No data" className="custom-class" />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('custom-class');
-  });
-
-  it('centers content', () => {
-    const { container } = render(<EmptyState title="No data" />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('flex', 'flex-col', 'items-center', 'justify-center', 'text-center');
+    expect(wrapper).toHaveClass(
+      "flex",
+      "flex-col",
+      "items-center",
+      "justify-center",
+      "text-center",
+    );
   });
 });

--- a/frontend/src/components/common/Loading.test.tsx
+++ b/frontend/src/components/common/Loading.test.tsx
@@ -1,70 +1,75 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { Loading, PageLoading } from './Loading';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { Loading, PageLoading } from "./Loading";
 
-describe('Loading', () => {
-  it('renders spinner', () => {
+describe("Loading", () => {
+  it("renders spinner", () => {
     const { container } = render(<Loading />);
-    const spinner = container.querySelector('.animate-spin');
+    const spinner = container.querySelector(".animate-spin");
     expect(spinner).toBeInTheDocument();
   });
 
-  it('applies small size', () => {
+  it("applies small size", () => {
     const { container } = render(<Loading size="sm" />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('h-4', 'w-4');
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toHaveClass("h-4", "w-4");
   });
 
-  it('applies medium size by default', () => {
+  it("applies medium size by default", () => {
     const { container } = render(<Loading />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('h-8', 'w-8');
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toHaveClass("h-8", "w-8");
   });
 
-  it('applies large size', () => {
+  it("applies large size", () => {
     const { container } = render(<Loading size="lg" />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('h-12', 'w-12');
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toHaveClass("h-12", "w-12");
   });
 
-  it('shows text when provided', () => {
+  it("shows text when provided", () => {
     render(<Loading text="Loading data..." />);
-    expect(screen.getByText('Loading data...')).toBeInTheDocument();
+    expect(screen.getByText("Loading data...")).toBeInTheDocument();
   });
 
-  it('does not show text when not provided', () => {
+  it("does not show text when not provided", () => {
     render(<Loading />);
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
-  it('applies custom className', () => {
+  it("applies custom className", () => {
     const { container } = render(<Loading className="custom-class" />);
     const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('custom-class');
+    expect(wrapper).toHaveClass("custom-class");
   });
 
-  it('applies flex layout styles', () => {
+  it("applies flex layout styles", () => {
     const { container } = render(<Loading />);
     const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('flex', 'flex-col', 'items-center', 'justify-center');
+    expect(wrapper).toHaveClass(
+      "flex",
+      "flex-col",
+      "items-center",
+      "justify-center",
+    );
   });
 });
 
-describe('PageLoading', () => {
-  it('renders loading component with text', () => {
+describe("PageLoading", () => {
+  it("renders loading component with text", () => {
     render(<PageLoading />);
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
-  it('renders with large size spinner', () => {
+  it("renders with large size spinner", () => {
     const { container } = render(<PageLoading />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('h-12', 'w-12');
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toHaveClass("h-12", "w-12");
   });
 
-  it('applies height styling', () => {
+  it("applies height styling", () => {
     const { container } = render(<PageLoading />);
     const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('h-64');
+    expect(wrapper).toHaveClass("h-64");
   });
 });

--- a/frontend/src/components/common/SearchInput.test.tsx
+++ b/frontend/src/components/common/SearchInput.test.tsx
@@ -1,52 +1,56 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { SearchInput } from './SearchInput';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { SearchInput } from "./SearchInput";
 
-describe('SearchInput', () => {
-  it('renders input element', () => {
+describe("SearchInput", () => {
+  it("renders input element", () => {
     render(<SearchInput />);
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it('renders with placeholder', () => {
+  it("renders with placeholder", () => {
     render(<SearchInput placeholder="Search..." />);
-    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
   });
 
-  it('displays value', () => {
+  it("displays value", () => {
     render(<SearchInput value="test query" onChange={() => {}} />);
-    expect(screen.getByRole('textbox')).toHaveValue('test query');
+    expect(screen.getByRole("textbox")).toHaveValue("test query");
   });
 
-  it('handles input change', () => {
+  it("handles input change", () => {
     const handleChange = vi.fn();
     render(<SearchInput onChange={handleChange} />);
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'new value' } });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "new value" },
+    });
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it('shows clear button when value is present', () => {
+  it("shows clear button when value is present", () => {
     render(<SearchInput value="test" onChange={() => {}} onClear={() => {}} />);
-    const clearButton = screen.getByRole('button');
+    const clearButton = screen.getByRole("button");
     expect(clearButton).toBeInTheDocument();
   });
 
-  it('calls onClear when clear button clicked', () => {
+  it("calls onClear when clear button clicked", () => {
     const handleClear = vi.fn();
-    render(<SearchInput value="test" onChange={() => {}} onClear={handleClear} />);
+    render(
+      <SearchInput value="test" onChange={() => {}} onClear={handleClear} />,
+    );
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole("button"));
     expect(handleClear).toHaveBeenCalledTimes(1);
   });
 
-  it('does not show clear button when value is empty', () => {
+  it("does not show clear button when value is empty", () => {
     render(<SearchInput value="" onChange={() => {}} onClear={() => {}} />);
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it('applies custom className to input', () => {
+  it("applies custom className to input", () => {
     render(<SearchInput className="custom-class" />);
-    expect(screen.getByRole('textbox')).toHaveClass('custom-class');
+    expect(screen.getByRole("textbox")).toHaveClass("custom-class");
   });
 });

--- a/frontend/src/components/common/Select.test.tsx
+++ b/frontend/src/components/common/Select.test.tsx
@@ -1,48 +1,64 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { Select } from './Select';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { Select } from "./Select";
 
 const options = [
-  { value: 'option1', label: 'Option 1' },
-  { value: 'option2', label: 'Option 2' },
-  { value: 'option3', label: 'Option 3' },
+  { value: "option1", label: "Option 1" },
+  { value: "option2", label: "Option 2" },
+  { value: "option3", label: "Option 3" },
 ];
 
-describe('Select', () => {
-  it('renders with placeholder', () => {
+describe("Select", () => {
+  it("renders with placeholder", () => {
     render(<Select options={options} placeholder="Select an option" />);
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it('renders all options', () => {
+  it("renders all options", () => {
     render(<Select options={options} placeholder="Select" />);
-    expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Option 2' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Option 3' })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option 2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option 3" }),
+    ).toBeInTheDocument();
   });
 
-  it('handles value change', () => {
+  it("handles value change", () => {
     const handleChange = vi.fn();
-    render(<Select options={options} placeholder="Select" onChange={handleChange} />);
+    render(
+      <Select options={options} placeholder="Select" onChange={handleChange} />,
+    );
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'option2' } });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "option2" },
+    });
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it('displays selected value', () => {
+  it("displays selected value", () => {
     render(<Select options={options} placeholder="Select" value="option2" />);
-    expect(screen.getByRole('combobox')).toHaveValue('option2');
+    expect(screen.getByRole("combobox")).toHaveValue("option2");
   });
 
-  it('applies custom className', () => {
-    render(<Select options={options} placeholder="Select" className="custom-class" />);
-    expect(screen.getByRole('combobox')).toHaveClass('custom-class');
+  it("applies custom className", () => {
+    render(
+      <Select
+        options={options}
+        placeholder="Select"
+        className="custom-class"
+      />,
+    );
+    expect(screen.getByRole("combobox")).toHaveClass("custom-class");
   });
 
-  it('shows placeholder as first option', () => {
+  it("shows placeholder as first option", () => {
     render(<Select options={options} placeholder="Choose..." />);
-    const firstOption = screen.getByRole('option', { name: 'Choose...' });
+    const firstOption = screen.getByRole("option", { name: "Choose..." });
     expect(firstOption).toBeInTheDocument();
-    expect(firstOption).toHaveValue('');
+    expect(firstOption).toHaveValue("");
   });
 });

--- a/frontend/src/components/common/StatusBadge.test.tsx
+++ b/frontend/src/components/common/StatusBadge.test.tsx
@@ -1,61 +1,65 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { StatusBadge } from './StatusBadge';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { StatusBadge } from "./StatusBadge";
 
-describe('StatusBadge', () => {
-  it('renders active status correctly', () => {
+describe("StatusBadge", () => {
+  it("renders active status correctly", () => {
     render(<StatusBadge status="active" />);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it('renders inactive status correctly', () => {
+  it("renders inactive status correctly", () => {
     render(<StatusBadge status="inactive" />);
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
   });
 
-  it('renders transitioning status correctly', () => {
+  it("renders transitioning status correctly", () => {
     render(<StatusBadge status="transitioning" />);
-    expect(screen.getByText('Transit')).toBeInTheDocument();
+    expect(screen.getByText("Transit")).toBeInTheDocument();
   });
 
-  it('renders error status correctly', () => {
+  it("renders error status correctly", () => {
     render(<StatusBadge status="error" />);
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
   });
 
-  it('shows dot by default', () => {
+  it("shows dot by default", () => {
     const { container } = render(<StatusBadge status="active" />);
-    const dot = container.querySelector('.rounded-full.h-2.w-2');
+    const dot = container.querySelector(".rounded-full.h-2.w-2");
     expect(dot).toBeInTheDocument();
   });
 
-  it('hides dot when showDot is false', () => {
-    const { container } = render(<StatusBadge status="active" showDot={false} />);
-    const dot = container.querySelector('.rounded-full.h-2.w-2');
+  it("hides dot when showDot is false", () => {
+    const { container } = render(
+      <StatusBadge status="active" showDot={false} />,
+    );
+    const dot = container.querySelector(".rounded-full.h-2.w-2");
     expect(dot).not.toBeInTheDocument();
   });
 
-  it('applies small size styles', () => {
+  it("applies small size styles", () => {
     const { container } = render(<StatusBadge status="active" size="sm" />);
     const badge = container.firstChild;
-    expect(badge).toHaveClass('text-xs');
+    expect(badge).toHaveClass("text-xs");
   });
 
-  it('applies medium size styles by default', () => {
+  it("applies medium size styles by default", () => {
     const { container } = render(<StatusBadge status="active" />);
     const badge = container.firstChild;
-    expect(badge).toHaveClass('text-sm');
+    expect(badge).toHaveClass("text-sm");
   });
 
-  it('applies custom className', () => {
-    const { container } = render(<StatusBadge status="active" className="custom-class" />);
+  it("applies custom className", () => {
+    const { container } = render(
+      <StatusBadge status="active" className="custom-class" />,
+    );
     const badge = container.firstChild;
-    expect(badge).toHaveClass('custom-class');
+    expect(badge).toHaveClass("custom-class");
   });
 
-  it('animates dot for transitioning status', () => {
+  it("animates dot for transitioning status", () => {
     const { container } = render(<StatusBadge status="transitioning" />);
-    const dot = container.querySelector('.animate-pulse');
+    const dot = container.querySelector(".animate-pulse");
     expect(dot).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/TerraformBadge.test.tsx
+++ b/frontend/src/components/common/TerraformBadge.test.tsx
@@ -1,51 +1,51 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { TerraformBadge } from './TerraformBadge';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { TerraformBadge } from "./TerraformBadge";
 
-describe('TerraformBadge', () => {
-  it('renders managed badge correctly', () => {
+describe("TerraformBadge", () => {
+  it("renders managed badge correctly", () => {
     render(<TerraformBadge managed={true} />);
-    expect(screen.getByText('Managed')).toBeInTheDocument();
+    expect(screen.getByText("Managed")).toBeInTheDocument();
   });
 
-  it('renders unmanaged badge correctly', () => {
+  it("renders unmanaged badge correctly", () => {
     render(<TerraformBadge managed={false} />);
-    expect(screen.getByText('Unmanaged')).toBeInTheDocument();
+    expect(screen.getByText("Unmanaged")).toBeInTheDocument();
   });
 
-  it('applies managed styling when managed is true', () => {
+  it("applies managed styling when managed is true", () => {
     render(<TerraformBadge managed={true} />);
-    const badge = screen.getByText('Managed');
-    expect(badge).toHaveClass('bg-purple-100');
-    expect(badge).toHaveClass('text-purple-700');
+    const badge = screen.getByText("Managed");
+    expect(badge).toHaveClass("bg-purple-100");
+    expect(badge).toHaveClass("text-purple-700");
   });
 
-  it('applies unmanaged styling when managed is false', () => {
+  it("applies unmanaged styling when managed is false", () => {
     render(<TerraformBadge managed={false} />);
-    const badge = screen.getByText('Unmanaged');
-    expect(badge).toHaveClass('bg-gray-100');
-    expect(badge).toHaveClass('text-gray-600');
+    const badge = screen.getByText("Unmanaged");
+    expect(badge).toHaveClass("bg-gray-100");
+    expect(badge).toHaveClass("text-gray-600");
   });
 
-  it('renders terraform icon', () => {
+  it("renders terraform icon", () => {
     const { container } = render(<TerraformBadge managed={true} />);
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
-    expect(svg).toHaveClass('h-3', 'w-3');
+    expect(svg).toHaveClass("h-3", "w-3");
   });
 
-  it('applies custom className', () => {
+  it("applies custom className", () => {
     render(<TerraformBadge managed={true} className="custom-class" />);
-    const badge = screen.getByText('Managed');
-    expect(badge).toHaveClass('custom-class');
+    const badge = screen.getByText("Managed");
+    expect(badge).toHaveClass("custom-class");
   });
 
-  it('has correct base styling', () => {
+  it("has correct base styling", () => {
     render(<TerraformBadge managed={true} />);
-    const badge = screen.getByText('Managed');
-    expect(badge).toHaveClass('inline-flex');
-    expect(badge).toHaveClass('items-center');
-    expect(badge).toHaveClass('text-xs');
-    expect(badge).toHaveClass('font-medium');
+    const badge = screen.getByText("Managed");
+    expect(badge).toHaveClass("inline-flex");
+    expect(badge).toHaveClass("items-center");
+    expect(badge).toHaveClass("text-xs");
+    expect(badge).toHaveClass("font-medium");
   });
 });

--- a/frontend/src/components/common/ThemeToggle.test.tsx
+++ b/frontend/src/components/common/ThemeToggle.test.tsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { ThemeToggle } from './ThemeToggle';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ThemeToggle } from "./ThemeToggle";
 
 // Mock the ThemeContext but preserve ThemeProvider for test-utils
 const mockToggleTheme = vi.fn();
-let mockTheme = 'light';
+let mockTheme = "light";
 
-vi.mock('../../contexts/ThemeContext', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../contexts/ThemeContext')>();
+vi.mock("../../contexts/ThemeContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../contexts/ThemeContext")>();
   return {
     ...actual,
     useTheme: () => ({
@@ -17,64 +18,64 @@ vi.mock('../../contexts/ThemeContext', async (importOriginal) => {
   };
 });
 
-describe('ThemeToggle', () => {
+describe("ThemeToggle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockTheme = 'light';
+    mockTheme = "light";
   });
 
-  it('renders toggle button', () => {
+  it("renders toggle button", () => {
     render(<ThemeToggle />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
   it('displays "Dark" text when in light mode', () => {
-    mockTheme = 'light';
+    mockTheme = "light";
     render(<ThemeToggle />);
-    expect(screen.getByText('Dark')).toBeInTheDocument();
+    expect(screen.getByText("Dark")).toBeInTheDocument();
   });
 
   it('displays "Light" text when in dark mode', () => {
-    mockTheme = 'dark';
+    mockTheme = "dark";
     render(<ThemeToggle />);
-    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByText("Light")).toBeInTheDocument();
   });
 
-  it('calls toggleTheme when clicked', () => {
+  it("calls toggleTheme when clicked", () => {
     render(<ThemeToggle />);
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole("button"));
     expect(mockToggleTheme).toHaveBeenCalledTimes(1);
   });
 
-  it('has correct aria-label for light mode', () => {
-    mockTheme = 'light';
+  it("has correct aria-label for light mode", () => {
+    mockTheme = "light";
     render(<ThemeToggle />);
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-label',
-      'Switch to dark mode'
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "Switch to dark mode",
     );
   });
 
-  it('has correct aria-label for dark mode', () => {
-    mockTheme = 'dark';
+  it("has correct aria-label for dark mode", () => {
+    mockTheme = "dark";
     render(<ThemeToggle />);
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-label',
-      'Switch to light mode'
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "Switch to light mode",
     );
   });
 
-  it('renders moon icon in light mode', () => {
-    mockTheme = 'light';
+  it("renders moon icon in light mode", () => {
+    mockTheme = "light";
     const { container } = render(<ThemeToggle />);
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
   });
 
-  it('renders sun icon in dark mode', () => {
-    mockTheme = 'dark';
+  it("renders sun icon in dark mode", () => {
+    mockTheme = "dark";
     const { container } = render(<ThemeToggle />);
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/ResourceSummaryCard.test.tsx
+++ b/frontend/src/components/dashboard/ResourceSummaryCard.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { ResourceSummaryCard } from './ResourceSummaryCard';
-import { Server } from 'lucide-react';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { ResourceSummaryCard } from "./ResourceSummaryCard";
+import { Server } from "lucide-react";
 
 const mockCounts = {
   total: 10,
@@ -11,85 +11,85 @@ const mockCounts = {
   error: 1,
 };
 
-describe('ResourceSummaryCard', () => {
-  it('renders title correctly', () => {
+describe("ResourceSummaryCard", () => {
+  it("renders title correctly", () => {
     render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    expect(screen.getByText('EC2 Instances')).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instances")).toBeInTheDocument();
   });
 
-  it('renders icon', () => {
+  it("renders icon", () => {
     render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
-  it('displays total count', () => {
+  it("displays total count", () => {
     render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
   });
 
-  it('displays all status counts', () => {
+  it("displays all status counts", () => {
     render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
     // '2' appears twice (inactive and transitioning)
-    expect(screen.getAllByText('2')).toHaveLength(2);
-    expect(screen.getByText('Transit')).toBeInTheDocument();
-    expect(screen.getByText('Error')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getAllByText("2")).toHaveLength(2);
+    expect(screen.getByText("Transit")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
   });
 
-  it('renders status labels correctly', () => {
+  it("renders status labels correctly", () => {
     render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
-    expect(screen.getByText('Transit')).toBeInTheDocument();
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(screen.getByText("Transit")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
   });
 
-  it('renders status indicators with correct styling', () => {
+  it("renders status indicators with correct styling", () => {
     const { container } = render(
       <ResourceSummaryCard
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={mockCounts}
-      />
+      />,
     );
-    const dots = container.querySelectorAll('.rounded-full');
+    const dots = container.querySelectorAll(".rounded-full");
     expect(dots.length).toBe(4); // active, inactive, transitioning, error
   });
 
-  it('renders with zero counts', () => {
+  it("renders with zero counts", () => {
     const zeroCounts = {
       total: 0,
       active: 0,
@@ -102,9 +102,9 @@ describe('ResourceSummaryCard', () => {
         title="EC2 Instances"
         icon={<Server data-testid="icon" />}
         counts={zeroCounts}
-      />
+      />,
     );
-    const zeros = screen.getAllByText('0');
+    const zeros = screen.getAllByText("0");
     expect(zeros.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/frontend/src/components/dashboard/ResourceSummaryCard.tsx
+++ b/frontend/src/components/dashboard/ResourceSummaryCard.tsx
@@ -1,7 +1,7 @@
-import { Link } from 'react-router-dom';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/common';
-import { cn, getStatusConfig } from '@/lib/utils';
-import type { ResourceCount, DisplayStatus } from '@/types';
+import { Link } from "react-router-dom";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/common";
+import { cn, getStatusConfig } from "@/lib/utils";
+import type { ResourceCount, DisplayStatus } from "@/types";
 
 interface ResourceSummaryCardProps {
   title: string;
@@ -23,7 +23,7 @@ export function ResourceSummaryCard({
   icon,
   counts,
   href,
-  linkText = 'View details',
+  linkText = "View details",
 }: ResourceSummaryCardProps) {
   return (
     <Card>

--- a/frontend/src/components/dashboard/StatusCard.test.tsx
+++ b/frontend/src/components/dashboard/StatusCard.test.tsx
@@ -1,98 +1,93 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { StatusCard } from './StatusCard';
-import { Server } from 'lucide-react';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { StatusCard } from "./StatusCard";
+import { Server } from "lucide-react";
 
-describe('StatusCard', () => {
-  it('renders title correctly', () => {
+describe("StatusCard", () => {
+  it("renders title correctly", () => {
     render(
       <StatusCard
         title="Running Instances"
         count={5}
         status="active"
         icon={<Server data-testid="icon" />}
-      />
+      />,
     );
-    expect(screen.getByText('Running Instances')).toBeInTheDocument();
+    expect(screen.getByText("Running Instances")).toBeInTheDocument();
   });
 
-  it('renders count correctly', () => {
+  it("renders count correctly", () => {
     render(
       <StatusCard
         title="Running Instances"
         count={5}
         status="active"
         icon={<Server data-testid="icon" />}
-      />
+      />,
     );
-    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
   });
 
-  it('renders icon', () => {
+  it("renders icon", () => {
     render(
       <StatusCard
         title="Running Instances"
         count={5}
         status="active"
         icon={<Server data-testid="icon" />}
-      />
+      />,
     );
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
-  it('applies active status styling', () => {
+  it("applies active status styling", () => {
     const { container } = render(
       <StatusCard
         title="Running"
         count={5}
         status="active"
         icon={<Server />}
-      />
+      />,
     );
-    const iconContainer = container.querySelector('.bg-green-50');
+    const iconContainer = container.querySelector(".bg-green-50");
     expect(iconContainer).toBeInTheDocument();
   });
 
-  it('applies error status styling', () => {
+  it("applies error status styling", () => {
     const { container } = render(
-      <StatusCard
-        title="Failed"
-        count={1}
-        status="error"
-        icon={<Server />}
-      />
+      <StatusCard title="Failed" count={1} status="error" icon={<Server />} />,
     );
-    const iconContainer = container.querySelector('.bg-red-50');
+    const iconContainer = container.querySelector(".bg-red-50");
     expect(iconContainer).toBeInTheDocument();
   });
 
-  it('applies inactive status styling', () => {
+  it("applies inactive status styling", () => {
     const { container } = render(
       <StatusCard
         title="Stopped"
         count={2}
         status="inactive"
         icon={<Server />}
-      />
+      />,
     );
-    const iconContainer = container.querySelector('.bg-gray-50');
+    const iconContainer = container.querySelector(".bg-gray-50");
     expect(iconContainer).toBeInTheDocument();
   });
 
-  it('applies transitioning status styling', () => {
+  it("applies transitioning status styling", () => {
     const { container } = render(
       <StatusCard
         title="Pending"
         count={1}
         status="transitioning"
         icon={<Server />}
-      />
+      />,
     );
-    const iconContainer = container.querySelector('.bg-yellow-50');
+    const iconContainer = container.querySelector(".bg-yellow-50");
     expect(iconContainer).toBeInTheDocument();
   });
 
-  it('handles click when onClick is provided', () => {
+  it("handles click when onClick is provided", () => {
     const handleClick = vi.fn();
     render(
       <StatusCard
@@ -101,15 +96,15 @@ describe('StatusCard', () => {
         status="active"
         icon={<Server />}
         onClick={handleClick}
-      />
+      />,
     );
 
-    const card = screen.getByText('Running').closest('div');
+    const card = screen.getByText("Running").closest("div");
     fireEvent.click(card!.parentElement!);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it('applies hover styling when clickable', () => {
+  it("applies hover styling when clickable", () => {
     const { container } = render(
       <StatusCard
         title="Running"
@@ -117,46 +112,46 @@ describe('StatusCard', () => {
         status="active"
         icon={<Server />}
         onClick={() => {}}
-      />
+      />,
     );
     const card = container.firstChild as HTMLElement;
-    expect(card).toHaveClass('cursor-pointer');
+    expect(card).toHaveClass("cursor-pointer");
   });
 
-  it('does not apply cursor-pointer when not clickable', () => {
+  it("does not apply cursor-pointer when not clickable", () => {
     const { container } = render(
       <StatusCard
         title="Running"
         count={5}
         status="active"
         icon={<Server />}
-      />
+      />,
     );
     const card = container.firstChild as HTMLElement;
-    expect(card).not.toHaveClass('cursor-pointer');
+    expect(card).not.toHaveClass("cursor-pointer");
   });
 
-  it('displays large counts correctly', () => {
+  it("displays large counts correctly", () => {
     render(
       <StatusCard
         title="Resources"
         count={9999}
         status="active"
         icon={<Server />}
-      />
+      />,
     );
-    expect(screen.getByText('9999')).toBeInTheDocument();
+    expect(screen.getByText("9999")).toBeInTheDocument();
   });
 
-  it('displays zero count correctly', () => {
+  it("displays zero count correctly", () => {
     render(
       <StatusCard
         title="Resources"
         count={0}
         status="inactive"
         icon={<Server />}
-      />
+      />,
     );
-    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { Header } from './Header';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { Header } from "./Header";
 
 // Mock the hooks
 const mockMutate = vi.fn();
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useStatusSummary: () => ({
     data: {
-      last_refreshed: '2024-01-15T12:00:00Z',
+      last_refreshed: "2024-01-15T12:00:00Z",
       total_resources: 10,
     },
   }),
@@ -17,50 +17,54 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('Header', () => {
+describe("Header", () => {
   beforeEach(() => {
     mockMutate.mockClear();
   });
 
-  it('renders header element', () => {
+  it("renders header element", () => {
     render(<Header />);
-    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole("banner")).toBeInTheDocument();
   });
 
-  it('renders application title', () => {
+  it("renders application title", () => {
     render(<Header />);
-    expect(screen.getByText('AWS Infrastructure Visualizer')).toBeInTheDocument();
+    expect(
+      screen.getByText("AWS Infrastructure Visualizer"),
+    ).toBeInTheDocument();
   });
 
-  it('renders last updated time', () => {
+  it("renders last updated time", () => {
     render(<Header />);
     expect(screen.getByText(/Last updated:/)).toBeInTheDocument();
   });
 
-  it('renders refresh button', () => {
+  it("renders refresh button", () => {
     render(<Header />);
-    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /refresh/i }),
+    ).toBeInTheDocument();
   });
 
-  it('calls refresh mutation when button clicked', () => {
+  it("calls refresh mutation when button clicked", () => {
     render(<Header />);
 
-    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
 
     expect(mockMutate).toHaveBeenCalledTimes(1);
     expect(mockMutate).toHaveBeenCalledWith(false);
   });
 
-  it('renders theme toggle', () => {
+  it("renders theme toggle", () => {
     render(<Header />);
     // ThemeToggle should be present
-    const buttons = screen.getAllByRole('button');
+    const buttons = screen.getAllByRole("button");
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders AWS logo', () => {
+  it("renders AWS logo", () => {
     render(<Header />);
-    const svg = document.querySelector('header svg');
+    const svg = document.querySelector("header svg");
     expect(svg).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
-import { RefreshCw, ScanEye } from 'lucide-react';
-import { Button } from '@/components/common';
-import { ThemeToggle } from '@/components/common/ThemeToggle';
-import { useRefreshData, useStatusSummary } from '@/hooks';
-import { formatRelativeTime } from '@/lib/utils';
+import { RefreshCw, ScanEye } from "lucide-react";
+import { Button } from "@/components/common";
+import { ThemeToggle } from "@/components/common/ThemeToggle";
+import { useRefreshData, useStatusSummary } from "@/hooks";
+import { formatRelativeTime } from "@/lib/utils";
 
 export function Header() {
   const { data: summary } = useStatusSummary();

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { Layout } from './Layout';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { Layout } from "./Layout";
 
 // Mock the hooks used by Header
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useStatusSummary: () => ({
     data: {
-      last_refreshed: '2024-01-15T12:00:00Z',
+      last_refreshed: "2024-01-15T12:00:00Z",
       total_resources: 10,
     },
   }),
@@ -17,38 +17,38 @@ vi.mock('@/hooks', () => ({
 }));
 
 // Mock react-router-dom's Outlet
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
     Outlet: () => <div data-testid="outlet">Outlet Content</div>,
   };
 });
 
-describe('Layout', () => {
-  it('renders the Header', () => {
+describe("Layout", () => {
+  it("renders the Header", () => {
     render(<Layout />);
-    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole("banner")).toBeInTheDocument();
   });
 
-  it('renders the Sidebar', () => {
+  it("renders the Sidebar", () => {
     render(<Layout />);
-    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
   });
 
-  it('renders the main content area', () => {
+  it("renders the main content area", () => {
     render(<Layout />);
-    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 
-  it('renders the Outlet for child routes', () => {
+  it("renders the Outlet for child routes", () => {
     render(<Layout />);
-    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
   });
 
-  it('has correct structure', () => {
+  it("has correct structure", () => {
     const { container } = render(<Layout />);
     const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass('min-h-screen');
+    expect(wrapper).toHaveClass("min-h-screen");
   });
 });

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -1,52 +1,73 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { Sidebar } from './Sidebar';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { Sidebar } from "./Sidebar";
 
-describe('Sidebar', () => {
-  it('renders navigation links', () => {
+describe("Sidebar", () => {
+  it("renders navigation links", () => {
     render(<Sidebar />);
 
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Topology')).toBeInTheDocument();
-    expect(screen.getByText('EC2 Instances')).toBeInTheDocument();
-    expect(screen.getByText('RDS Databases')).toBeInTheDocument();
-    expect(screen.getByText('VPC Networking')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Topology")).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instances")).toBeInTheDocument();
+    expect(screen.getByText("RDS Databases")).toBeInTheDocument();
+    expect(screen.getByText("VPC Networking")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('renders settings link', () => {
+  it("renders settings link", () => {
     render(<Sidebar />);
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
-  it('renders as aside element', () => {
+  it("renders as aside element", () => {
     render(<Sidebar />);
-    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
   });
 
-  it('renders navigation element', () => {
+  it("renders navigation element", () => {
     render(<Sidebar />);
-    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
   });
 
-  it('links have correct hrefs', () => {
+  it("links have correct hrefs", () => {
     render(<Sidebar />);
 
-    expect(screen.getByText('Dashboard').closest('a')).toHaveAttribute('href', '/');
-    expect(screen.getByText('Topology').closest('a')).toHaveAttribute('href', '/topology');
-    expect(screen.getByText('EC2 Instances').closest('a')).toHaveAttribute('href', '/ec2');
-    expect(screen.getByText('RDS Databases').closest('a')).toHaveAttribute('href', '/rds');
-    expect(screen.getByText('VPC Networking').closest('a')).toHaveAttribute('href', '/vpc');
-    expect(screen.getByText('Terraform').closest('a')).toHaveAttribute('href', '/terraform');
-    expect(screen.getByText('Settings').closest('a')).toHaveAttribute('href', '/settings');
+    expect(screen.getByText("Dashboard").closest("a")).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(screen.getByText("Topology").closest("a")).toHaveAttribute(
+      "href",
+      "/topology",
+    );
+    expect(screen.getByText("EC2 Instances").closest("a")).toHaveAttribute(
+      "href",
+      "/ec2",
+    );
+    expect(screen.getByText("RDS Databases").closest("a")).toHaveAttribute(
+      "href",
+      "/rds",
+    );
+    expect(screen.getByText("VPC Networking").closest("a")).toHaveAttribute(
+      "href",
+      "/vpc",
+    );
+    expect(screen.getByText("Terraform").closest("a")).toHaveAttribute(
+      "href",
+      "/terraform",
+    );
+    expect(screen.getByText("Settings").closest("a")).toHaveAttribute(
+      "href",
+      "/settings",
+    );
   });
 
-  it('each navigation item has an icon', () => {
+  it("each navigation item has an icon", () => {
     render(<Sidebar />);
-    const links = screen.getAllByRole('link');
+    const links = screen.getAllByRole("link");
 
     links.forEach((link) => {
-      const svg = link.querySelector('svg');
+      const svg = link.querySelector("svg");
       expect(svg).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/resources/ResourceDetailPanel.test.tsx
+++ b/frontend/src/components/resources/ResourceDetailPanel.test.tsx
@@ -1,254 +1,266 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { EC2DetailPanel, RDSDetailPanel } from './ResourceDetailPanel';
-import type { EC2Instance, RDSInstance } from '@/types';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { EC2DetailPanel, RDSDetailPanel } from "./ResourceDetailPanel";
+import type { EC2Instance, RDSInstance } from "@/types";
 
 const mockEC2Instance: EC2Instance = {
   id: 1,
-  instance_id: 'i-1234567890abcdef0',
-  name: 'Test EC2 Instance',
-  instance_type: 't3.micro',
-  state: 'running',
-  display_status: 'active',
-  region_name: 'us-east-1',
-  availability_zone: 'us-east-1a',
-  private_ip: '10.0.1.100',
-  public_ip: '54.123.45.67',
-  private_dns: 'ip-10-0-1-100.ec2.internal',
-  public_dns: 'ec2-54-123-45-67.compute-1.amazonaws.com',
-  vpc_id: 'vpc-12345678',
-  subnet_id: 'subnet-12345678',
+  instance_id: "i-1234567890abcdef0",
+  name: "Test EC2 Instance",
+  instance_type: "t3.micro",
+  state: "running",
+  display_status: "active",
+  region_name: "us-east-1",
+  availability_zone: "us-east-1a",
+  private_ip: "10.0.1.100",
+  public_ip: "54.123.45.67",
+  private_dns: "ip-10-0-1-100.ec2.internal",
+  public_dns: "ec2-54-123-45-67.compute-1.amazonaws.com",
+  vpc_id: "vpc-12345678",
+  subnet_id: "subnet-12345678",
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_instance.web_server',
-  launch_time: '2024-01-15T10:30:00Z',
-  updated_at: '2024-01-15T12:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_instance.web_server",
+  launch_time: "2024-01-15T10:30:00Z",
+  updated_at: "2024-01-15T12:00:00Z",
   is_deleted: false,
   deleted_at: null,
   tags: {
-    Environment: 'Production',
-    Team: 'DevOps',
+    Environment: "Production",
+    Team: "DevOps",
   },
 };
 
 const mockRDSInstance: RDSInstance = {
   id: 1,
-  db_instance_identifier: 'prod-db-01',
-  name: 'Production Database',
-  db_instance_class: 'db.t3.micro',
-  status: 'available',
-  display_status: 'active',
-  region_name: 'us-east-1',
-  engine: 'mysql',
-  engine_version: '8.0.28',
+  db_instance_identifier: "prod-db-01",
+  name: "Production Database",
+  db_instance_class: "db.t3.micro",
+  status: "available",
+  display_status: "active",
+  region_name: "us-east-1",
+  engine: "mysql",
+  engine_version: "8.0.28",
   allocated_storage: 100,
   multi_az: true,
-  endpoint: 'prod-db-01.abc123.us-east-1.rds.amazonaws.com',
+  endpoint: "prod-db-01.abc123.us-east-1.rds.amazonaws.com",
   port: 3306,
-  vpc_id: 'vpc-12345678',
-  availability_zone: 'us-east-1a',
+  vpc_id: "vpc-12345678",
+  availability_zone: "us-east-1a",
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_db_instance.main',
-  updated_at: '2024-01-15T12:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_db_instance.main",
+  updated_at: "2024-01-15T12:00:00Z",
   is_deleted: false,
   deleted_at: null,
   tags: null,
 };
 
-describe('EC2DetailPanel', () => {
+describe("EC2DetailPanel", () => {
   const mockOnClose = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders instance details header', () => {
+  it("renders instance details header", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Instance Details')).toBeInTheDocument();
+    expect(screen.getByText("Instance Details")).toBeInTheDocument();
   });
 
-  it('renders instance name', () => {
+  it("renders instance name", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Test EC2 Instance')).toBeInTheDocument();
+    expect(screen.getByText("Test EC2 Instance")).toBeInTheDocument();
   });
 
-  it('renders instance ID when no name', () => {
-    const instanceWithoutName = { ...mockEC2Instance, name: '' };
-    render(<EC2DetailPanel instance={instanceWithoutName} onClose={mockOnClose} />);
+  it("renders instance ID when no name", () => {
+    const instanceWithoutName = { ...mockEC2Instance, name: "" };
+    render(
+      <EC2DetailPanel instance={instanceWithoutName} onClose={mockOnClose} />,
+    );
     // Instance ID appears both as title and in Basic Info section
-    const instanceIds = screen.getAllByText('i-1234567890abcdef0');
+    const instanceIds = screen.getAllByText("i-1234567890abcdef0");
     expect(instanceIds).toHaveLength(2);
   });
 
-  it('renders status badge', () => {
+  it("renders status badge", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it('renders terraform badge', () => {
+  it("renders terraform badge", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Managed')).toBeInTheDocument();
+    expect(screen.getByText("Managed")).toBeInTheDocument();
   });
 
-  it('renders basic info section', () => {
+  it("renders basic info section", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Basic Info')).toBeInTheDocument();
-    expect(screen.getByText('Instance ID')).toBeInTheDocument();
-    expect(screen.getByText('Type')).toBeInTheDocument();
-    expect(screen.getByText('t3.micro')).toBeInTheDocument();
-    expect(screen.getByText('State')).toBeInTheDocument();
-    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText("Basic Info")).toBeInTheDocument();
+    expect(screen.getByText("Instance ID")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("t3.micro")).toBeInTheDocument();
+    expect(screen.getByText("State")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
   });
 
-  it('renders network section', () => {
+  it("renders network section", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Network')).toBeInTheDocument();
-    expect(screen.getByText('Private IP')).toBeInTheDocument();
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
-    expect(screen.getByText('Public IP')).toBeInTheDocument();
-    expect(screen.getByText('54.123.45.67')).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
+    expect(screen.getByText("Private IP")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
+    expect(screen.getByText("Public IP")).toBeInTheDocument();
+    expect(screen.getByText("54.123.45.67")).toBeInTheDocument();
   });
 
-  it('renders terraform section when managed', () => {
+  it("renders terraform section when managed", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
-    expect(screen.getByText('State File')).toBeInTheDocument();
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('Address')).toBeInTheDocument();
-    expect(screen.getByText('aws_instance.web_server')).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+    expect(screen.getByText("State File")).toBeInTheDocument();
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("Address")).toBeInTheDocument();
+    expect(screen.getByText("aws_instance.web_server")).toBeInTheDocument();
   });
 
-  it('does not render terraform section when not managed', () => {
+  it("does not render terraform section when not managed", () => {
     const unmanagedInstance = { ...mockEC2Instance, tf_managed: false };
-    render(<EC2DetailPanel instance={unmanagedInstance} onClose={mockOnClose} />);
-    expect(screen.queryByText('State File')).not.toBeInTheDocument();
+    render(
+      <EC2DetailPanel instance={unmanagedInstance} onClose={mockOnClose} />,
+    );
+    expect(screen.queryByText("State File")).not.toBeInTheDocument();
   });
 
-  it('renders timestamps section', () => {
+  it("renders timestamps section", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Timestamps')).toBeInTheDocument();
-    expect(screen.getByText('Launched')).toBeInTheDocument();
-    expect(screen.getByText('Last Updated')).toBeInTheDocument();
+    expect(screen.getByText("Timestamps")).toBeInTheDocument();
+    expect(screen.getByText("Launched")).toBeInTheDocument();
+    expect(screen.getByText("Last Updated")).toBeInTheDocument();
   });
 
-  it('renders tags section when tags exist', () => {
+  it("renders tags section when tags exist", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
-    expect(screen.getByText('Tags')).toBeInTheDocument();
-    expect(screen.getByText('Environment')).toBeInTheDocument();
-    expect(screen.getByText('Production')).toBeInTheDocument();
-    expect(screen.getByText('Team')).toBeInTheDocument();
-    expect(screen.getByText('DevOps')).toBeInTheDocument();
+    expect(screen.getByText("Tags")).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("DevOps")).toBeInTheDocument();
   });
 
-  it('does not render tags section when no tags', () => {
+  it("does not render tags section when no tags", () => {
     const instanceWithoutTags = { ...mockEC2Instance, tags: {} };
-    render(<EC2DetailPanel instance={instanceWithoutTags} onClose={mockOnClose} />);
-    expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+    render(
+      <EC2DetailPanel instance={instanceWithoutTags} onClose={mockOnClose} />,
+    );
+    expect(screen.queryByText("Tags")).not.toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it("calls onClose when close button is clicked", () => {
     render(<EC2DetailPanel instance={mockEC2Instance} onClose={mockOnClose} />);
     // Get the first button which is the close button (there are copy buttons too)
-    const buttons = screen.getAllByRole('button');
+    const buttons = screen.getAllByRole("button");
     fireEvent.click(buttons[0]);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('RDSDetailPanel', () => {
+describe("RDSDetailPanel", () => {
   const mockOnClose = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders database details header', () => {
+  it("renders database details header", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Database Details')).toBeInTheDocument();
+    expect(screen.getByText("Database Details")).toBeInTheDocument();
   });
 
-  it('renders database name', () => {
+  it("renders database name", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Production Database')).toBeInTheDocument();
+    expect(screen.getByText("Production Database")).toBeInTheDocument();
   });
 
-  it('renders identifier when no name', () => {
-    const instanceWithoutName = { ...mockRDSInstance, name: '' };
-    render(<RDSDetailPanel instance={instanceWithoutName} onClose={mockOnClose} />);
+  it("renders identifier when no name", () => {
+    const instanceWithoutName = { ...mockRDSInstance, name: "" };
+    render(
+      <RDSDetailPanel instance={instanceWithoutName} onClose={mockOnClose} />,
+    );
     // Identifier appears both as title and in Basic Info section
-    const identifiers = screen.getAllByText('prod-db-01');
+    const identifiers = screen.getAllByText("prod-db-01");
     expect(identifiers).toHaveLength(2);
   });
 
-  it('renders status badge', () => {
+  it("renders status badge", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it('renders terraform badge', () => {
+  it("renders terraform badge", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Managed')).toBeInTheDocument();
+    expect(screen.getByText("Managed")).toBeInTheDocument();
   });
 
-  it('renders basic info section', () => {
+  it("renders basic info section", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Basic Info')).toBeInTheDocument();
-    expect(screen.getByText('Identifier')).toBeInTheDocument();
-    expect(screen.getByText('prod-db-01')).toBeInTheDocument();
-    expect(screen.getByText('Class')).toBeInTheDocument();
-    expect(screen.getByText('db.t3.micro')).toBeInTheDocument();
+    expect(screen.getByText("Basic Info")).toBeInTheDocument();
+    expect(screen.getByText("Identifier")).toBeInTheDocument();
+    expect(screen.getByText("prod-db-01")).toBeInTheDocument();
+    expect(screen.getByText("Class")).toBeInTheDocument();
+    expect(screen.getByText("db.t3.micro")).toBeInTheDocument();
   });
 
-  it('renders database section', () => {
+  it("renders database section", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Database')).toBeInTheDocument();
-    expect(screen.getByText('Engine')).toBeInTheDocument();
-    expect(screen.getByText('mysql 8.0.28')).toBeInTheDocument();
-    expect(screen.getByText('Storage')).toBeInTheDocument();
-    expect(screen.getByText('100 GB')).toBeInTheDocument();
-    expect(screen.getByText('Multi-AZ')).toBeInTheDocument();
-    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText("Database")).toBeInTheDocument();
+    expect(screen.getByText("Engine")).toBeInTheDocument();
+    expect(screen.getByText("mysql 8.0.28")).toBeInTheDocument();
+    expect(screen.getByText("Storage")).toBeInTheDocument();
+    expect(screen.getByText("100 GB")).toBeInTheDocument();
+    expect(screen.getByText("Multi-AZ")).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
   });
 
-  it('renders Multi-AZ as No when false', () => {
+  it("renders Multi-AZ as No when false", () => {
     const singleAZInstance = { ...mockRDSInstance, multi_az: false };
-    render(<RDSDetailPanel instance={singleAZInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('No')).toBeInTheDocument();
+    render(
+      <RDSDetailPanel instance={singleAZInstance} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("No")).toBeInTheDocument();
   });
 
-  it('renders connection section', () => {
+  it("renders connection section", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Connection')).toBeInTheDocument();
-    expect(screen.getByText('Endpoint')).toBeInTheDocument();
-    expect(screen.getByText('Port')).toBeInTheDocument();
-    expect(screen.getByText('3306')).toBeInTheDocument();
+    expect(screen.getByText("Connection")).toBeInTheDocument();
+    expect(screen.getByText("Endpoint")).toBeInTheDocument();
+    expect(screen.getByText("Port")).toBeInTheDocument();
+    expect(screen.getByText("3306")).toBeInTheDocument();
   });
 
-  it('renders terraform section when managed', () => {
+  it("renders terraform section when managed", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
-    expect(screen.getByText('State File')).toBeInTheDocument();
-    expect(screen.getByText('Address')).toBeInTheDocument();
-    expect(screen.getByText('aws_db_instance.main')).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+    expect(screen.getByText("State File")).toBeInTheDocument();
+    expect(screen.getByText("Address")).toBeInTheDocument();
+    expect(screen.getByText("aws_db_instance.main")).toBeInTheDocument();
   });
 
-  it('does not render terraform section when not managed', () => {
+  it("does not render terraform section when not managed", () => {
     const unmanagedInstance = { ...mockRDSInstance, tf_managed: false };
-    render(<RDSDetailPanel instance={unmanagedInstance} onClose={mockOnClose} />);
-    expect(screen.queryByText('State File')).not.toBeInTheDocument();
+    render(
+      <RDSDetailPanel instance={unmanagedInstance} onClose={mockOnClose} />,
+    );
+    expect(screen.queryByText("State File")).not.toBeInTheDocument();
   });
 
-  it('renders timestamps section', () => {
+  it("renders timestamps section", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
-    expect(screen.getByText('Timestamps')).toBeInTheDocument();
-    expect(screen.getByText('Last Updated')).toBeInTheDocument();
+    expect(screen.getByText("Timestamps")).toBeInTheDocument();
+    expect(screen.getByText("Last Updated")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it("calls onClose when close button is clicked", () => {
     render(<RDSDetailPanel instance={mockRDSInstance} onClose={mockOnClose} />);
     // Get the first button which is the close button (there are copy buttons too)
-    const buttons = screen.getAllByRole('button');
+    const buttons = screen.getAllByRole("button");
     fireEvent.click(buttons[0]);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/components/resources/ResourceDetailPanel.tsx
+++ b/frontend/src/components/resources/ResourceDetailPanel.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { X, Copy, Check } from 'lucide-react';
-import { Button, StatusBadge, TerraformBadge } from '@/components/common';
-import { formatDateTime } from '@/lib/utils';
-import type { EC2Instance, RDSInstance } from '@/types';
+import { useState } from "react";
+import { X, Copy, Check } from "lucide-react";
+import { Button, StatusBadge, TerraformBadge } from "@/components/common";
+import { formatDateTime } from "@/lib/utils";
+import type { EC2Instance, RDSInstance } from "@/types";
 
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -13,21 +13,21 @@ function CopyButton({ value }: { value: string }) {
       if (navigator.clipboard && window.isSecureContext) {
         await navigator.clipboard.writeText(value);
       } else {
-        const textArea = document.createElement('textarea');
+        const textArea = document.createElement("textarea");
         textArea.value = value;
-        textArea.style.position = 'fixed';
-        textArea.style.left = '-999999px';
-        textArea.style.top = '-999999px';
+        textArea.style.position = "fixed";
+        textArea.style.left = "-999999px";
+        textArea.style.top = "-999999px";
         document.body.appendChild(textArea);
         textArea.focus();
         textArea.select();
-        document.execCommand('copy');
+        document.execCommand("copy");
         textArea.remove();
       }
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error('Failed to copy:', err);
+      console.error("Failed to copy:", err);
     }
   };
 
@@ -37,7 +37,11 @@ function CopyButton({ value }: { value: string }) {
       className="ml-1 shrink-0 rounded p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-600 dark:hover:text-gray-300"
       title="Copy to clipboard"
     >
-      {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
     </button>
   );
 }
@@ -68,7 +72,9 @@ interface CopyableDetailRowProps {
 function CopyableDetailRow({ label, value }: CopyableDetailRowProps) {
   return (
     <div className="flex justify-between gap-4 py-2">
-      <span className="flex-shrink-0 text-sm text-gray-500 dark:text-gray-400">{label}</span>
+      <span className="flex-shrink-0 text-sm text-gray-500 dark:text-gray-400">
+        {label}
+      </span>
       <span className="flex items-center break-all text-right text-sm font-medium text-gray-900 dark:text-gray-100">
         {value ? (
           <>
@@ -76,7 +82,7 @@ function CopyableDetailRow({ label, value }: CopyableDetailRowProps) {
             <CopyButton value={value} />
           </>
         ) : (
-          '-'
+          "-"
         )}
       </span>
     </div>
@@ -116,7 +122,10 @@ export function EC2DetailPanel({ instance, onClose }: EC2DetailPanelProps) {
               Basic Info
             </h4>
             <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
-              <CopyableDetailRow label="Instance ID" value={instance.instance_id} />
+              <CopyableDetailRow
+                label="Instance ID"
+                value={instance.instance_id}
+              />
               <DetailRow label="Type" value={instance.instance_type} />
               <DetailRow label="State" value={instance.state} />
               <DetailRow label="Region" value={instance.region_name} />
@@ -129,10 +138,19 @@ export function EC2DetailPanel({ instance, onClose }: EC2DetailPanelProps) {
               Network
             </h4>
             <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
-              <CopyableDetailRow label="Private IP" value={instance.private_ip} />
+              <CopyableDetailRow
+                label="Private IP"
+                value={instance.private_ip}
+              />
               <CopyableDetailRow label="Public IP" value={instance.public_ip} />
-              <CopyableDetailRow label="Private DNS" value={instance.private_dns} />
-              <CopyableDetailRow label="Public DNS" value={instance.public_dns} />
+              <CopyableDetailRow
+                label="Private DNS"
+                value={instance.private_dns}
+              />
+              <CopyableDetailRow
+                label="Public DNS"
+                value={instance.public_dns}
+              />
               <DetailRow label="VPC ID" value={instance.vpc_id} />
               <DetailRow label="Subnet ID" value={instance.subnet_id} />
             </div>
@@ -259,7 +277,10 @@ export function RDSDetailPanel({ instance, onClose }: RDSDetailPanelProps) {
             </h4>
             <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
               <CopyableDetailRow label="Endpoint" value={instance.endpoint} />
-              <CopyableDetailRow label="Port" value={instance.port?.toString()} />
+              <CopyableDetailRow
+                label="Port"
+                value={instance.port?.toString()}
+              />
               <DetailRow label="VPC ID" value={instance.vpc_id} />
               <DetailRow label="AZ" value={instance.availability_zone} />
             </div>

--- a/frontend/src/components/resources/ResourceFilters.test.tsx
+++ b/frontend/src/components/resources/ResourceFilters.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { ResourceFilters } from './ResourceFilters';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ResourceFilters } from "./ResourceFilters";
 
-describe('ResourceFilters', () => {
+describe("ResourceFilters", () => {
   const mockOnFilterChange = vi.fn();
 
   beforeEach(() => {
@@ -14,91 +14,93 @@ describe('ResourceFilters', () => {
     vi.useRealTimers();
   });
 
-  it('renders search input', () => {
+  it("renders search input", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 
-  it('renders status select', () => {
+  it("renders status select", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
-    expect(screen.getByText('All statuses')).toBeInTheDocument();
+    expect(screen.getByText("All statuses")).toBeInTheDocument();
   });
 
-  it('renders terraform filter by default', () => {
+  it("renders terraform filter by default", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
-    expect(screen.getByText('All resources')).toBeInTheDocument();
+    expect(screen.getByText("All resources")).toBeInTheDocument();
   });
 
-  it('hides terraform filter when showTerraformFilter is false', () => {
+  it("hides terraform filter when showTerraformFilter is false", () => {
     render(
       <ResourceFilters
         filters={{}}
         onFilterChange={mockOnFilterChange}
         showTerraformFilter={false}
-      />
+      />,
     );
-    expect(screen.queryByText('All resources')).not.toBeInTheDocument();
+    expect(screen.queryByText("All resources")).not.toBeInTheDocument();
   });
 
-  it('shows clear button when filters are active', () => {
+  it("shows clear button when filters are active", () => {
     render(
       <ResourceFilters
-        filters={{ search: 'test' }}
+        filters={{ search: "test" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
-    expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    expect(screen.getByText("Clear filters")).toBeInTheDocument();
   });
 
-  it('does not show clear button when no filters are active', () => {
+  it("does not show clear button when no filters are active", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
-    expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
+    expect(screen.queryByText("Clear filters")).not.toBeInTheDocument();
   });
 
-  it('calls onFilterChange when status is selected', () => {
+  it("calls onFilterChange when status is selected", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
 
     // Get all comboboxes - first one is status, second is terraform
-    const selects = screen.getAllByRole('combobox');
+    const selects = screen.getAllByRole("combobox");
     const statusSelect = selects[0];
-    fireEvent.change(statusSelect, { target: { value: 'active' } });
+    fireEvent.change(statusSelect, { target: { value: "active" } });
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({
-      status: 'active',
+      status: "active",
     });
   });
 
-  it('calls onFilterChange when terraform filter is selected', () => {
+  it("calls onFilterChange when terraform filter is selected", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
 
-    const selects = screen.getAllByRole('combobox');
+    const selects = screen.getAllByRole("combobox");
     const terraformSelect = selects[1];
-    fireEvent.change(terraformSelect, { target: { value: 'true' } });
+    fireEvent.change(terraformSelect, { target: { value: "true" } });
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({
       tf_managed: true,
     });
   });
 
-  it('debounces search input', async () => {
+  it("debounces search input", async () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
 
-    const searchInput = screen.getByPlaceholderText('Search by name or ID...');
-    fireEvent.change(searchInput, { target: { value: 'test' } });
+    const searchInput = screen.getByPlaceholderText("Search by name or ID...");
+    fireEvent.change(searchInput, { target: { value: "test" } });
 
     // Should not be called immediately
     expect(mockOnFilterChange).not.toHaveBeenCalled();
@@ -107,99 +109,99 @@ describe('ResourceFilters', () => {
     vi.advanceTimersByTime(400);
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({
-      search: 'test',
+      search: "test",
     });
   });
 
-  it('clears all filters when clear button is clicked', () => {
+  it("clears all filters when clear button is clicked", () => {
     render(
       <ResourceFilters
-        filters={{ search: 'test', status: 'active' }}
+        filters={{ search: "test", status: "active" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
 
-    fireEvent.click(screen.getByText('Clear filters'));
+    fireEvent.click(screen.getByText("Clear filters"));
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({});
   });
 
-  it('displays current search value', () => {
+  it("displays current search value", () => {
     render(
       <ResourceFilters
-        filters={{ search: 'my search' }}
+        filters={{ search: "my search" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
 
-    expect(screen.getByDisplayValue('my search')).toBeInTheDocument();
+    expect(screen.getByDisplayValue("my search")).toBeInTheDocument();
   });
 
-  it('syncs search input with external filter changes', () => {
+  it("syncs search input with external filter changes", () => {
     const { rerender } = render(
       <ResourceFilters
-        filters={{ search: 'initial' }}
+        filters={{ search: "initial" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
 
-    expect(screen.getByDisplayValue('initial')).toBeInTheDocument();
+    expect(screen.getByDisplayValue("initial")).toBeInTheDocument();
 
     rerender(
       <ResourceFilters
-        filters={{ search: 'updated' }}
+        filters={{ search: "updated" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
 
-    expect(screen.getByDisplayValue('updated')).toBeInTheDocument();
+    expect(screen.getByDisplayValue("updated")).toBeInTheDocument();
   });
 
-  it('shows clear button when status filter is active', () => {
+  it("shows clear button when status filter is active", () => {
     render(
       <ResourceFilters
-        filters={{ status: 'active' }}
+        filters={{ status: "active" }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
-    expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    expect(screen.getByText("Clear filters")).toBeInTheDocument();
   });
 
-  it('shows clear button when tf_managed filter is active', () => {
+  it("shows clear button when tf_managed filter is active", () => {
     render(
       <ResourceFilters
         filters={{ tf_managed: true }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
-    expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    expect(screen.getByText("Clear filters")).toBeInTheDocument();
   });
 
-  it('sets tf_managed to false when unmanaged is selected', () => {
+  it("sets tf_managed to false when unmanaged is selected", () => {
     render(
-      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />
+      <ResourceFilters filters={{}} onFilterChange={mockOnFilterChange} />,
     );
 
-    const selects = screen.getAllByRole('combobox');
+    const selects = screen.getAllByRole("combobox");
     const terraformSelect = selects[1];
-    fireEvent.change(terraformSelect, { target: { value: 'false' } });
+    fireEvent.change(terraformSelect, { target: { value: "false" } });
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({
       tf_managed: false,
     });
   });
 
-  it('clears tf_managed when empty value is selected', () => {
+  it("clears tf_managed when empty value is selected", () => {
     render(
       <ResourceFilters
         filters={{ tf_managed: true }}
         onFilterChange={mockOnFilterChange}
-      />
+      />,
     );
 
-    const selects = screen.getAllByRole('combobox');
+    const selects = screen.getAllByRole("combobox");
     const terraformSelect = selects[1];
-    fireEvent.change(terraformSelect, { target: { value: '' } });
+    fireEvent.change(terraformSelect, { target: { value: "" } });
 
     expect(mockOnFilterChange).toHaveBeenCalledWith({
       tf_managed: undefined,

--- a/frontend/src/components/resources/ResourceTable.test.tsx
+++ b/frontend/src/components/resources/ResourceTable.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { ResourceTable } from './ResourceTable';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ResourceTable } from "./ResourceTable";
 
 interface TestItem {
   id: string;
@@ -9,75 +9,75 @@ interface TestItem {
 }
 
 const mockData: TestItem[] = [
-  { id: '1', name: 'Item 1', status: 'active' },
-  { id: '2', name: 'Item 2', status: 'inactive' },
-  { id: '3', name: 'Item 3', status: 'error' },
+  { id: "1", name: "Item 1", status: "active" },
+  { id: "2", name: "Item 2", status: "inactive" },
+  { id: "3", name: "Item 3", status: "error" },
 ];
 
 const mockColumns = [
-  { key: 'id', header: 'ID', render: (item: TestItem) => item.id },
-  { key: 'name', header: 'Name', render: (item: TestItem) => item.name },
-  { key: 'status', header: 'Status', render: (item: TestItem) => item.status },
+  { key: "id", header: "ID", render: (item: TestItem) => item.id },
+  { key: "name", header: "Name", render: (item: TestItem) => item.name },
+  { key: "status", header: "Status", render: (item: TestItem) => item.status },
 ];
 
-describe('ResourceTable', () => {
-  it('renders table headers', () => {
+describe("ResourceTable", () => {
+  it("renders table headers", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    expect(screen.getByText('ID')).toBeInTheDocument();
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText("ID")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
-  it('renders table data', () => {
+  it("renders table data", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    expect(screen.getByText('Item 1')).toBeInTheDocument();
-    expect(screen.getByText('Item 2')).toBeInTheDocument();
-    expect(screen.getByText('Item 3')).toBeInTheDocument();
-    expect(screen.getByText('active')).toBeInTheDocument();
-    expect(screen.getByText('inactive')).toBeInTheDocument();
-    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(screen.getByText("Item 1")).toBeInTheDocument();
+    expect(screen.getByText("Item 2")).toBeInTheDocument();
+    expect(screen.getByText("Item 3")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("inactive")).toBeInTheDocument();
+    expect(screen.getByText("error")).toBeInTheDocument();
   });
 
-  it('renders empty message when data is empty', () => {
+  it("renders empty message when data is empty", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={[]}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(screen.getByText("No data available")).toBeInTheDocument();
   });
 
-  it('renders custom empty message', () => {
+  it("renders custom empty message", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={[]}
         keyExtractor={(item) => item.id}
         emptyMessage="No items found"
-      />
+      />,
     );
 
-    expect(screen.getByText('No items found')).toBeInTheDocument();
+    expect(screen.getByText("No items found")).toBeInTheDocument();
   });
 
-  it('calls onRowClick when row is clicked', () => {
+  it("calls onRowClick when row is clicked", () => {
     const handleRowClick = vi.fn();
     render(
       <ResourceTable
@@ -85,51 +85,51 @@ describe('ResourceTable', () => {
         data={mockData}
         keyExtractor={(item) => item.id}
         onRowClick={handleRowClick}
-      />
+      />,
     );
 
-    fireEvent.click(screen.getByText('Item 1'));
+    fireEvent.click(screen.getByText("Item 1"));
     expect(handleRowClick).toHaveBeenCalledWith(mockData[0]);
   });
 
-  it('applies cursor-pointer to rows when onRowClick is provided', () => {
+  it("applies cursor-pointer to rows when onRowClick is provided", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
         onRowClick={() => {}}
-      />
+      />,
     );
 
-    const rows = screen.getAllByRole('row').slice(1); // Skip header row
+    const rows = screen.getAllByRole("row").slice(1); // Skip header row
     rows.forEach((row) => {
-      expect(row).toHaveClass('cursor-pointer');
+      expect(row).toHaveClass("cursor-pointer");
     });
   });
 
-  it('does not apply cursor-pointer when onRowClick is not provided', () => {
+  it("does not apply cursor-pointer when onRowClick is not provided", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    const rows = screen.getAllByRole('row').slice(1);
+    const rows = screen.getAllByRole("row").slice(1);
     rows.forEach((row) => {
-      expect(row).not.toHaveClass('cursor-pointer');
+      expect(row).not.toHaveClass("cursor-pointer");
     });
   });
 
-  it('applies custom className to columns', () => {
+  it("applies custom className to columns", () => {
     const columnsWithClass = [
       {
-        key: 'id',
-        header: 'ID',
+        key: "id",
+        header: "ID",
         render: (item: TestItem) => item.id,
-        className: 'custom-column',
+        className: "custom-column",
       },
     ];
 
@@ -138,35 +138,35 @@ describe('ResourceTable', () => {
         columns={columnsWithClass}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    const header = screen.getByText('ID');
-    expect(header).toHaveClass('custom-column');
+    const header = screen.getByText("ID");
+    expect(header).toHaveClass("custom-column");
   });
 
-  it('renders correct number of rows', () => {
+  it("renders correct number of rows", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    const rows = screen.getAllByRole('row');
+    const rows = screen.getAllByRole("row");
     expect(rows).toHaveLength(4); // 1 header + 3 data rows
   });
 
-  it('renders table element', () => {
+  it("renders table element", () => {
     render(
       <ResourceTable
         columns={mockColumns}
         data={mockData}
         keyExtractor={(item) => item.id}
-      />
+      />,
     );
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/InfrastructureTopology.test.tsx
+++ b/frontend/src/components/topology/InfrastructureTopology.test.tsx
@@ -1,11 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/test/test-utils';
-import { InfrastructureTopology } from './InfrastructureTopology';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import { InfrastructureTopology } from "./InfrastructureTopology";
 
 // Mock interfaces for topology components
 interface MockTopologyCanvasProps {
   data?: { vpcs?: { vpc_id: string }[] };
-  onNodeClick?: (id: string, type: string, data: { label: string; type: string }) => void;
+  onNodeClick?: (
+    id: string,
+    type: string,
+    data: { label: string; type: string },
+  ) => void;
 }
 
 interface MockTopologyLegendProps {
@@ -13,12 +17,14 @@ interface MockTopologyLegendProps {
 }
 
 // Mock the topology components
-vi.mock('./TopologyCanvas', () => ({
+vi.mock("./TopologyCanvas", () => ({
   TopologyCanvas: ({ data, onNodeClick }: MockTopologyCanvasProps) => (
     <div data-testid="topology-canvas">
       <button
         data-testid="test-node"
-        onClick={() => onNodeClick?.('node-1', 'ec2', { label: 'Test Node', type: 'ec2' })}
+        onClick={() =>
+          onNodeClick?.("node-1", "ec2", { label: "Test Node", type: "ec2" })
+        }
       >
         Test Node
       </button>
@@ -27,7 +33,7 @@ vi.mock('./TopologyCanvas', () => ({
   ),
 }));
 
-vi.mock('./TopologyLegend', () => ({
+vi.mock("./TopologyLegend", () => ({
   TopologyLegend: ({ stats }: MockTopologyLegendProps) => (
     <div data-testid="topology-legend">
       {stats && <span>Stats: {stats.total_vpcs} VPCs</span>}
@@ -38,10 +44,10 @@ vi.mock('./TopologyLegend', () => ({
 const mockTopologyData = {
   vpcs: [
     {
-      vpc_id: 'vpc-123',
-      name: 'Test VPC',
-      cidr_block: '10.0.0.0/16',
-      display_status: 'active',
+      vpc_id: "vpc-123",
+      name: "Test VPC",
+      cidr_block: "10.0.0.0/16",
+      display_status: "active",
       tf_managed: true,
     },
   ],
@@ -60,7 +66,7 @@ let mockError: Error | null = null;
 const mockRefetch = vi.fn();
 const mockMutateAsync = vi.fn();
 
-vi.mock('@/hooks/useResources', () => ({
+vi.mock("@/hooks/useResources", () => ({
   useTopology: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -74,7 +80,7 @@ vi.mock('@/hooks/useResources', () => ({
   }),
 }));
 
-describe('InfrastructureTopology', () => {
+describe("InfrastructureTopology", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockData = mockTopologyData;
@@ -83,93 +89,104 @@ describe('InfrastructureTopology', () => {
     mockError = null;
   });
 
-  it('renders loading state', () => {
+  it("renders loading state", () => {
     mockIsLoading = true;
     mockData = null;
     render(<InfrastructureTopology />);
-    expect(screen.getByText('Loading infrastructure topology...')).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading infrastructure topology..."),
+    ).toBeInTheDocument();
   });
 
-  it('renders error state', () => {
+  it("renders error state", () => {
     mockIsError = true;
-    mockError = new Error('Network error');
+    mockError = new Error("Network error");
     mockData = null;
     render(<InfrastructureTopology />);
-    expect(screen.getByText('Failed to load topology')).toBeInTheDocument();
-    expect(screen.getByText('Network error')).toBeInTheDocument();
+    expect(screen.getByText("Failed to load topology")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
   });
 
-  it('renders error state with generic message when error is not an Error instance', () => {
+  it("renders error state with generic message when error is not an Error instance", () => {
     mockIsError = true;
     mockError = null;
     mockData = null;
     render(<InfrastructureTopology />);
-    expect(screen.getByText('An error occurred')).toBeInTheDocument();
+    expect(screen.getByText("An error occurred")).toBeInTheDocument();
   });
 
-  it('renders retry button in error state', () => {
+  it("renders retry button in error state", () => {
     mockIsError = true;
     mockData = null;
     render(<InfrastructureTopology />);
-    expect(screen.getByText('Retry')).toBeInTheDocument();
+    expect(screen.getByText("Retry")).toBeInTheDocument();
   });
 
-  it('calls refetch when retry button is clicked', () => {
+  it("calls refetch when retry button is clicked", () => {
     mockIsError = true;
     mockData = null;
     render(<InfrastructureTopology />);
-    fireEvent.click(screen.getByText('Retry'));
+    fireEvent.click(screen.getByText("Retry"));
     expect(mockRefetch).toHaveBeenCalled();
   });
 
-  it('renders empty state when no VPCs', () => {
+  it("renders empty state when no VPCs", () => {
     mockData = { ...mockTopologyData, vpcs: [] };
     render(<InfrastructureTopology />);
-    expect(screen.getByText('No Terraform-managed infrastructure found')).toBeInTheDocument();
+    expect(
+      screen.getByText("No Terraform-managed infrastructure found"),
+    ).toBeInTheDocument();
   });
 
-  it('renders empty state when data is null', () => {
+  it("renders empty state when data is null", () => {
     mockData = null;
     render(<InfrastructureTopology />);
-    expect(screen.getByText('No Terraform-managed infrastructure found')).toBeInTheDocument();
+    expect(
+      screen.getByText("No Terraform-managed infrastructure found"),
+    ).toBeInTheDocument();
   });
 
-  it('renders refresh button in empty state', () => {
+  it("renders refresh button in empty state", () => {
     mockData = { ...mockTopologyData, vpcs: [] };
     render(<InfrastructureTopology />);
-    expect(screen.getByText('Refresh Data')).toBeInTheDocument();
+    expect(screen.getByText("Refresh Data")).toBeInTheDocument();
   });
 
-  it('calls refresh when refresh button is clicked', async () => {
+  it("calls refresh when refresh button is clicked", async () => {
     mockData = { ...mockTopologyData, vpcs: [] };
     render(<InfrastructureTopology />);
-    fireEvent.click(screen.getByText('Refresh Data'));
+    fireEvent.click(screen.getByText("Refresh Data"));
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith(false);
     });
   });
 
-  it('renders topology canvas when data is available', () => {
+  it("renders topology canvas when data is available", () => {
     render(<InfrastructureTopology />);
-    expect(screen.getByTestId('topology-canvas')).toBeInTheDocument();
+    expect(screen.getByTestId("topology-canvas")).toBeInTheDocument();
   });
 
-  it('renders topology legend when data is available', () => {
+  it("renders topology legend when data is available", () => {
     render(<InfrastructureTopology />);
-    expect(screen.getByTestId('topology-legend')).toBeInTheDocument();
+    expect(screen.getByTestId("topology-legend")).toBeInTheDocument();
   });
 
-  it('calls onResourceSelect when node is clicked', () => {
+  it("calls onResourceSelect when node is clicked", () => {
     const mockOnResourceSelect = vi.fn();
     render(<InfrastructureTopology onResourceSelect={mockOnResourceSelect} />);
 
-    fireEvent.click(screen.getByTestId('test-node'));
-    expect(mockOnResourceSelect).toHaveBeenCalledWith({ label: 'Test Node', type: 'ec2' });
+    fireEvent.click(screen.getByTestId("test-node"));
+    expect(mockOnResourceSelect).toHaveBeenCalledWith({
+      label: "Test Node",
+      type: "ec2",
+    });
   });
 
-  it('handles undefined onResourceSelect gracefully', () => {
+  it("handles undefined onResourceSelect gracefully", () => {
     render(<InfrastructureTopology />);
     // Should not throw when clicking without onResourceSelect
-    expect(() => fireEvent.click(screen.getByTestId('test-node'))).not.toThrow();
+    expect(() =>
+      fireEvent.click(screen.getByTestId("test-node")),
+    ).not.toThrow();
   });
 });

--- a/frontend/src/components/topology/TopologyCanvas.test.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.test.tsx
@@ -1,14 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { TopologyCanvas } from './TopologyCanvas';
-import type { TopologyResponse } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { TopologyCanvas } from "./TopologyCanvas";
+import type { TopologyResponse } from "@/types/topology";
 
 // Mock interfaces for ReactFlow
 interface MockReactFlowProps {
   children?: React.ReactNode;
   nodes?: unknown[];
   edges?: unknown[];
-  onNodeClick?: (event: React.MouseEvent, node: { id: string; type: string; data: { label: string } }) => void;
+  onNodeClick?: (
+    event: React.MouseEvent,
+    node: { id: string; type: string; data: { label: string } },
+  ) => void;
 }
 
 interface MockNode {
@@ -18,10 +21,23 @@ interface MockNode {
 }
 
 // Mock ReactFlow and related imports
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   default: ({ children, nodes, edges, onNodeClick }: MockReactFlowProps) => (
-    <div data-testid="react-flow" data-nodes={JSON.stringify(nodes)} data-edges={JSON.stringify(edges)}>
-      <button data-testid="mock-node" onClick={(e) => onNodeClick?.(e, { id: 'node-1', type: 'ec2', data: { label: 'test' } })}>
+    <div
+      data-testid="react-flow"
+      data-nodes={JSON.stringify(nodes)}
+      data-edges={JSON.stringify(edges)}
+    >
+      <button
+        data-testid="mock-node"
+        onClick={(e) =>
+          onNodeClick?.(e, {
+            id: "node-1",
+            type: "ec2",
+            data: { label: "test" },
+          })
+        }
+      >
         Mock Node
       </button>
       {children}
@@ -30,44 +46,54 @@ vi.mock('reactflow', () => ({
   Background: () => <div data-testid="react-flow-background" />,
   Controls: () => <div data-testid="react-flow-controls" />,
   useNodesState: (initialNodes: MockNode[]) => [initialNodes, vi.fn(), vi.fn()],
-  useEdgesState: (initialEdges: { id: string; source: string; target: string }[]) => [initialEdges, vi.fn(), vi.fn()],
-  BackgroundVariant: { Dots: 'dots' },
+  useEdgesState: (
+    initialEdges: { id: string; source: string; target: string }[],
+  ) => [initialEdges, vi.fn(), vi.fn()],
+  BackgroundVariant: { Dots: "dots" },
 }));
 
 // Mock the layout calculator
-vi.mock('./utils/layoutCalculator', () => ({
+vi.mock("./utils/layoutCalculator", () => ({
   calculateTopologyLayout: () => ({
     nodes: [
-      { id: 'vpc-1', type: 'vpc', position: { x: 0, y: 0 }, data: { label: 'Test VPC' } },
-      { id: 'subnet-1', type: 'subnet', position: { x: 10, y: 10 }, data: { label: 'Test Subnet' } },
+      {
+        id: "vpc-1",
+        type: "vpc",
+        position: { x: 0, y: 0 },
+        data: { label: "Test VPC" },
+      },
+      {
+        id: "subnet-1",
+        type: "subnet",
+        position: { x: 10, y: 10 },
+        data: { label: "Test Subnet" },
+      },
     ],
     edges: [],
   }),
-  createEdges: () => [
-    { id: 'edge-1', source: 'vpc-1', target: 'subnet-1' },
-  ],
+  createEdges: () => [{ id: "edge-1", source: "vpc-1", target: "subnet-1" }],
 }));
 
 const mockTopologyData: TopologyResponse = {
   vpcs: [
     {
-      id: 'vpc-123',
-      name: 'Test VPC',
-      cidr_block: '10.0.0.0/16',
-      state: 'available',
-      display_status: 'active',
+      id: "vpc-123",
+      name: "Test VPC",
+      cidr_block: "10.0.0.0/16",
+      state: "available",
+      display_status: "active",
       tf_managed: true,
       tf_resource_address: null,
       internet_gateway: null,
       elastic_ips: [],
       subnets: [
         {
-          id: 'subnet-123',
-          name: 'Test Subnet',
-          cidr_block: '10.0.1.0/24',
-          availability_zone: 'us-east-1a',
-          subnet_type: 'public',
-          display_status: 'active',
+          id: "subnet-123",
+          name: "Test Subnet",
+          cidr_block: "10.0.1.0/24",
+          availability_zone: "us-east-1a",
+          subnet_type: "public",
+          display_status: "active",
           tf_managed: true,
           tf_resource_address: null,
           nat_gateway: null,
@@ -85,47 +111,51 @@ const mockTopologyData: TopologyResponse = {
     total_nat_gateways: 0,
     total_internet_gateways: 0,
     total_elastic_ips: 0,
-    last_refreshed: '2024-01-15T12:00:00Z',
+    last_refreshed: "2024-01-15T12:00:00Z",
   },
 };
 
-describe('TopologyCanvas', () => {
-  it('renders ReactFlow component', () => {
+describe("TopologyCanvas", () => {
+  it("renders ReactFlow component", () => {
     render(<TopologyCanvas data={mockTopologyData} />);
-    expect(screen.getByTestId('react-flow')).toBeInTheDocument();
+    expect(screen.getByTestId("react-flow")).toBeInTheDocument();
   });
 
-  it('renders ReactFlow background', () => {
+  it("renders ReactFlow background", () => {
     render(<TopologyCanvas data={mockTopologyData} />);
-    expect(screen.getByTestId('react-flow-background')).toBeInTheDocument();
+    expect(screen.getByTestId("react-flow-background")).toBeInTheDocument();
   });
 
-  it('renders ReactFlow controls', () => {
+  it("renders ReactFlow controls", () => {
     render(<TopologyCanvas data={mockTopologyData} />);
-    expect(screen.getByTestId('react-flow-controls')).toBeInTheDocument();
+    expect(screen.getByTestId("react-flow-controls")).toBeInTheDocument();
   });
 
-  it('calls onNodeClick when node is clicked', () => {
+  it("calls onNodeClick when node is clicked", () => {
     const mockOnNodeClick = vi.fn();
-    render(<TopologyCanvas data={mockTopologyData} onNodeClick={mockOnNodeClick} />);
+    render(
+      <TopologyCanvas data={mockTopologyData} onNodeClick={mockOnNodeClick} />,
+    );
 
-    const mockNode = screen.getByTestId('mock-node');
+    const mockNode = screen.getByTestId("mock-node");
     fireEvent.click(mockNode);
 
-    expect(mockOnNodeClick).toHaveBeenCalledWith('node-1', 'ec2', { label: 'test' });
+    expect(mockOnNodeClick).toHaveBeenCalledWith("node-1", "ec2", {
+      label: "test",
+    });
   });
 
-  it('does not throw when onNodeClick is not provided', () => {
+  it("does not throw when onNodeClick is not provided", () => {
     render(<TopologyCanvas data={mockTopologyData} />);
 
-    const mockNode = screen.getByTestId('mock-node');
+    const mockNode = screen.getByTestId("mock-node");
     expect(() => fireEvent.click(mockNode)).not.toThrow();
   });
 
-  it('renders within a container div', () => {
+  it("renders within a container div", () => {
     const { container } = render(<TopologyCanvas data={mockTopologyData} />);
     const wrapperDiv = container.firstChild as HTMLElement;
-    expect(wrapperDiv.className).toContain('w-full');
-    expect(wrapperDiv.className).toContain('h-full');
+    expect(wrapperDiv.className).toContain("w-full");
+    expect(wrapperDiv.className).toContain("h-full");
   });
 });

--- a/frontend/src/components/topology/TopologyLegend.test.tsx
+++ b/frontend/src/components/topology/TopologyLegend.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { TopologyLegend } from './TopologyLegend';
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { TopologyLegend } from "./TopologyLegend";
 
-describe('TopologyLegend', () => {
+describe("TopologyLegend", () => {
   const mockStats = {
     total_vpcs: 2,
     total_subnets: 6,
@@ -10,94 +10,96 @@ describe('TopologyLegend', () => {
     total_rds: 3,
   };
 
-  it('renders the legend header', () => {
+  it("renders the legend header", () => {
     render(<TopologyLegend />);
-    expect(screen.getByText('Legend')).toBeInTheDocument();
+    expect(screen.getByText("Legend")).toBeInTheDocument();
   });
 
-  it('renders stats when provided', () => {
+  it("renders stats when provided", () => {
     render(<TopologyLegend stats={mockStats} />);
-    expect(screen.getByText('VPCs:')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('Subnets:')).toBeInTheDocument();
-    expect(screen.getByText('6')).toBeInTheDocument();
-    expect(screen.getByText('EC2:')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
-    expect(screen.getByText('RDS:')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText("VPCs:")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Subnets:")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("EC2:")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("RDS:")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it('does not render stats section when stats not provided', () => {
+  it("does not render stats section when stats not provided", () => {
     render(<TopologyLegend />);
-    expect(screen.queryByText('VPCs:')).not.toBeInTheDocument();
+    expect(screen.queryByText("VPCs:")).not.toBeInTheDocument();
   });
 
-  it('expands legend content when clicked', () => {
+  it("expands legend content when clicked", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
     fireEvent.click(legendButton);
 
     // Should show resource types
-    expect(screen.getByText('VPC')).toBeInTheDocument();
-    expect(screen.getByText('Subnet')).toBeInTheDocument();
-    expect(screen.getByText('EC2 Instance')).toBeInTheDocument();
-    expect(screen.getByText('RDS Database')).toBeInTheDocument();
-    expect(screen.getByText('Internet Gateway')).toBeInTheDocument();
-    expect(screen.getByText('NAT Gateway')).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
+    expect(screen.getByText("Subnet")).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instance")).toBeInTheDocument();
+    expect(screen.getByText("RDS Database")).toBeInTheDocument();
+    expect(screen.getByText("Internet Gateway")).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateway")).toBeInTheDocument();
   });
 
-  it('shows status indicators when expanded', () => {
+  it("shows status indicators when expanded", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
     fireEvent.click(legendButton);
 
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
-    expect(screen.getByText('Transit')).toBeInTheDocument();
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(screen.getByText("Transit")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
   });
 
-  it('shows subnet types when expanded', () => {
+  it("shows subnet types when expanded", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
     fireEvent.click(legendButton);
 
-    expect(screen.getByText('Public')).toBeInTheDocument();
-    expect(screen.getByText('Private')).toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
   });
 
-  it('shows terraform managed indicator when expanded', () => {
+  it("shows terraform managed indicator when expanded", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
     fireEvent.click(legendButton);
 
-    expect(screen.getByText('TF')).toBeInTheDocument();
-    expect(screen.getByText('Terraform Managed')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
+    expect(screen.getByText("Terraform Managed")).toBeInTheDocument();
   });
 
-  it('collapses when clicked again', () => {
+  it("collapses when clicked again", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
 
     // Expand
     fireEvent.click(legendButton);
-    expect(screen.getByText('VPC')).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
 
     // Collapse
     fireEvent.click(legendButton);
     // The content should be hidden (opacity-0)
-    const legendContent = screen.getByText('VPC').closest('.space-y-4')?.parentElement;
-    expect(legendContent?.className).toContain('max-h-0');
-    expect(legendContent?.className).toContain('opacity-0');
+    const legendContent = screen
+      .getByText("VPC")
+      .closest(".space-y-4")?.parentElement;
+    expect(legendContent?.className).toContain("max-h-0");
+    expect(legendContent?.className).toContain("opacity-0");
   });
 
-  it('shows section headers when expanded', () => {
+  it("shows section headers when expanded", () => {
     render(<TopologyLegend />);
-    const legendButton = screen.getByText('Legend');
+    const legendButton = screen.getByText("Legend");
     fireEvent.click(legendButton);
 
-    expect(screen.getByText('Resources')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Subnet Types')).toBeInTheDocument();
+    expect(screen.getByText("Resources")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Subnet Types")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/nodes/EC2Node.test.tsx
+++ b/frontend/src/components/topology/nodes/EC2Node.test.tsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { EC2Node } from './EC2Node';
-import type { EC2NodeData } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { EC2Node } from "./EC2Node";
+import type { EC2NodeData } from "@/types/topology";
 
 // Mock react-flow
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   Handle: ({ type, position }: { type: string; position: string }) => (
     <div data-testid={`handle-${type}-${position}`} />
   ),
   Position: {
-    Top: 'top',
-    Bottom: 'bottom',
-    Left: 'left',
-    Right: 'right',
+    Top: "top",
+    Bottom: "bottom",
+    Left: "left",
+    Right: "right",
   },
 }));
 
 const defaultData: EC2NodeData = {
-  type: 'ec2',
-  label: 'web-server-1',
-  instanceId: 'i-1234567890abcdef0',
-  instanceType: 't3.micro',
-  displayStatus: 'active',
-  privateIp: '10.0.1.100',
+  type: "ec2",
+  label: "web-server-1",
+  instanceId: "i-1234567890abcdef0",
+  instanceType: "t3.micro",
+  displayStatus: "active",
+  privateIp: "10.0.1.100",
   tfManaged: false,
-  state: 'running',
+  state: "running",
 };
 
 const createNodeProps = (data: EC2NodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'ec2',
+  type: "ec2",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -41,82 +41,82 @@ const createNodeProps = (data: EC2NodeData) => ({
   positionAbsoluteY: 0,
 });
 
-describe('EC2Node', () => {
-  it('renders the node label', () => {
+describe("EC2Node", () => {
+  it("renders the node label", () => {
     render(<EC2Node {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('web-server-1')).toBeInTheDocument();
+    expect(screen.getByText("web-server-1")).toBeInTheDocument();
   });
 
-  it('renders the instance type', () => {
+  it("renders the instance type", () => {
     render(<EC2Node {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('t3.micro')).toBeInTheDocument();
+    expect(screen.getByText("t3.micro")).toBeInTheDocument();
   });
 
-  it('renders the private IP when provided', () => {
+  it("renders the private IP when provided", () => {
     render(<EC2Node {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
   });
 
-  it('does not render private IP when not provided', () => {
+  it("does not render private IP when not provided", () => {
     const data = { ...defaultData, privateIp: undefined };
     render(<EC2Node {...createNodeProps(data)} />);
-    expect(screen.queryByText('10.0.1.100')).not.toBeInTheDocument();
+    expect(screen.queryByText("10.0.1.100")).not.toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultData, tfManaged: true };
     render(<EC2Node {...createNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<EC2Node {...createNodeProps(defaultData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultData, label: "" };
     render(<EC2Node {...createNodeProps(data)} />);
-    expect(screen.getByText('EC2')).toBeInTheDocument();
+    expect(screen.getByText("EC2")).toBeInTheDocument();
   });
 
-  it('renders with active status styling', () => {
+  it("renders with active status styling", () => {
     const { container } = render(<EC2Node {...createNodeProps(defaultData)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-500');
+    expect(nodeDiv.className).toContain("border-green-500");
   });
 
-  it('renders with inactive status styling', () => {
-    const data = { ...defaultData, displayStatus: 'inactive' as const };
+  it("renders with inactive status styling", () => {
+    const data = { ...defaultData, displayStatus: "inactive" as const };
     const { container } = render(<EC2Node {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-400');
+    expect(nodeDiv.className).toContain("border-gray-400");
   });
 
-  it('renders with transitioning status styling', () => {
-    const data = { ...defaultData, displayStatus: 'transitioning' as const };
+  it("renders with transitioning status styling", () => {
+    const data = { ...defaultData, displayStatus: "transitioning" as const };
     const { container } = render(<EC2Node {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-yellow-500');
+    expect(nodeDiv.className).toContain("border-yellow-500");
   });
 
-  it('renders with error status styling', () => {
-    const data = { ...defaultData, displayStatus: 'error' as const };
+  it("renders with error status styling", () => {
+    const data = { ...defaultData, displayStatus: "error" as const };
     const { container } = render(<EC2Node {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-red-500');
+    expect(nodeDiv.className).toContain("border-red-500");
   });
 
-  it('renders with unknown status styling', () => {
-    const data = { ...defaultData, displayStatus: 'unknown' as const };
+  it("renders with unknown status styling", () => {
+    const data = { ...defaultData, displayStatus: "unknown" as const };
     const { container } = render(<EC2Node {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-300');
+    expect(nodeDiv.className).toContain("border-gray-300");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<EC2Node {...createNodeProps(defaultData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/nodes/GatewayNode.test.tsx
+++ b/frontend/src/components/topology/nodes/GatewayNode.test.tsx
@@ -1,25 +1,28 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { InternetGatewayNode, NATGatewayNode } from './GatewayNode';
-import type { InternetGatewayNodeData, NATGatewayNodeData } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { InternetGatewayNode, NATGatewayNode } from "./GatewayNode";
+import type {
+  InternetGatewayNodeData,
+  NATGatewayNodeData,
+} from "@/types/topology";
 
 // Mock react-flow
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   Handle: ({ type, position }: { type: string; position: string }) => (
     <div data-testid={`handle-${type}-${position}`} />
   ),
   Position: {
-    Top: 'top',
-    Bottom: 'bottom',
-    Left: 'left',
-    Right: 'right',
+    Top: "top",
+    Bottom: "bottom",
+    Left: "left",
+    Right: "right",
   },
 }));
 
 const createIGWNodeProps = (data: InternetGatewayNodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'internet-gateway',
+  type: "internet-gateway",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -31,9 +34,9 @@ const createIGWNodeProps = (data: InternetGatewayNodeData) => ({
 });
 
 const createNATNodeProps = (data: NATGatewayNodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'nat-gateway',
+  type: "nat-gateway",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -44,135 +47,147 @@ const createNATNodeProps = (data: NATGatewayNodeData) => ({
   positionAbsoluteY: 0,
 });
 
-describe('InternetGatewayNode', () => {
+describe("InternetGatewayNode", () => {
   const defaultIGWData: InternetGatewayNodeData = {
-    type: 'internet-gateway',
-    label: 'main-igw',
-    igwId: 'igw-12345',
-    displayStatus: 'active',
+    type: "internet-gateway",
+    label: "main-igw",
+    igwId: "igw-12345",
+    displayStatus: "active",
     tfManaged: false,
   };
 
-  it('renders the node label', () => {
+  it("renders the node label", () => {
     render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
-    expect(screen.getByText('main-igw')).toBeInTheDocument();
+    expect(screen.getByText("main-igw")).toBeInTheDocument();
   });
 
-  it('renders the IGW ID', () => {
+  it("renders the IGW ID", () => {
     render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
-    expect(screen.getByText('igw-12345')).toBeInTheDocument();
+    expect(screen.getByText("igw-12345")).toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultIGWData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultIGWData, label: "" };
     render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
-    expect(screen.getByText('IGW')).toBeInTheDocument();
+    expect(screen.getByText("IGW")).toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultIGWData, tfManaged: true };
     render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders with active status styling', () => {
-    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
+  it("renders with active status styling", () => {
+    const { container } = render(
+      <InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-500');
+    expect(nodeDiv.className).toContain("border-green-500");
   });
 
-  it('renders with inactive status styling', () => {
-    const data = { ...defaultIGWData, displayStatus: 'inactive' as const };
-    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
+  it("renders with inactive status styling", () => {
+    const data = { ...defaultIGWData, displayStatus: "inactive" as const };
+    const { container } = render(
+      <InternetGatewayNode {...createIGWNodeProps(data)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-400');
+    expect(nodeDiv.className).toContain("border-gray-400");
   });
 
-  it('renders with transitioning status styling', () => {
-    const data = { ...defaultIGWData, displayStatus: 'transitioning' as const };
-    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
+  it("renders with transitioning status styling", () => {
+    const data = { ...defaultIGWData, displayStatus: "transitioning" as const };
+    const { container } = render(
+      <InternetGatewayNode {...createIGWNodeProps(data)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-yellow-500');
+    expect(nodeDiv.className).toContain("border-yellow-500");
   });
 
-  it('renders with error status styling', () => {
-    const data = { ...defaultIGWData, displayStatus: 'error' as const };
-    const { container } = render(<InternetGatewayNode {...createIGWNodeProps(data)} />);
+  it("renders with error status styling", () => {
+    const data = { ...defaultIGWData, displayStatus: "error" as const };
+    const { container } = render(
+      <InternetGatewayNode {...createIGWNodeProps(data)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-red-500');
+    expect(nodeDiv.className).toContain("border-red-500");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<InternetGatewayNode {...createIGWNodeProps(defaultIGWData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });
 
-describe('NATGatewayNode', () => {
+describe("NATGatewayNode", () => {
   const defaultNATData: NATGatewayNodeData = {
-    type: 'nat-gateway',
-    label: 'nat-gw-1',
-    natGatewayId: 'nat-12345',
-    displayStatus: 'active',
-    publicIp: '54.1.2.3',
+    type: "nat-gateway",
+    label: "nat-gw-1",
+    natGatewayId: "nat-12345",
+    displayStatus: "active",
+    publicIp: "54.1.2.3",
     tfManaged: false,
   };
 
-  it('renders the node label', () => {
+  it("renders the node label", () => {
     render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
-    expect(screen.getByText('nat-gw-1')).toBeInTheDocument();
+    expect(screen.getByText("nat-gw-1")).toBeInTheDocument();
   });
 
-  it('renders the public IP when provided', () => {
+  it("renders the public IP when provided", () => {
     render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
   });
 
-  it('does not render public IP when not provided', () => {
+  it("does not render public IP when not provided", () => {
     const data = { ...defaultNATData, publicIp: undefined };
     render(<NATGatewayNode {...createNATNodeProps(data)} />);
-    expect(screen.queryByText('54.1.2.3')).not.toBeInTheDocument();
+    expect(screen.queryByText("54.1.2.3")).not.toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultNATData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultNATData, label: "" };
     render(<NATGatewayNode {...createNATNodeProps(data)} />);
-    expect(screen.getByText('NAT')).toBeInTheDocument();
+    expect(screen.getByText("NAT")).toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultNATData, tfManaged: true };
     render(<NATGatewayNode {...createNATNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders with active status styling', () => {
-    const { container } = render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
+  it("renders with active status styling", () => {
+    const { container } = render(
+      <NATGatewayNode {...createNATNodeProps(defaultNATData)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-500');
+    expect(nodeDiv.className).toContain("border-green-500");
   });
 
-  it('renders with inactive status styling', () => {
-    const data = { ...defaultNATData, displayStatus: 'inactive' as const };
-    const { container } = render(<NATGatewayNode {...createNATNodeProps(data)} />);
+  it("renders with inactive status styling", () => {
+    const data = { ...defaultNATData, displayStatus: "inactive" as const };
+    const { container } = render(
+      <NATGatewayNode {...createNATNodeProps(data)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-400');
+    expect(nodeDiv.className).toContain("border-gray-400");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<NATGatewayNode {...createNATNodeProps(defaultNATData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/nodes/RDSNode.test.tsx
+++ b/frontend/src/components/topology/nodes/RDSNode.test.tsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { RDSNode } from './RDSNode';
-import type { RDSNodeData } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { RDSNode } from "./RDSNode";
+import type { RDSNodeData } from "@/types/topology";
 
 // Mock react-flow
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   Handle: ({ type, position }: { type: string; position: string }) => (
     <div data-testid={`handle-${type}-${position}`} />
   ),
   Position: {
-    Top: 'top',
-    Bottom: 'bottom',
-    Left: 'left',
-    Right: 'right',
+    Top: "top",
+    Bottom: "bottom",
+    Left: "left",
+    Right: "right",
   },
 }));
 
 const defaultData: RDSNodeData = {
-  type: 'rds',
-  label: 'prod-database',
-  dbIdentifier: 'prod-db-01',
-  engine: 'mysql 8.0',
-  instanceClass: 'db.t3.micro',
-  displayStatus: 'active',
-  status: 'available',
+  type: "rds",
+  label: "prod-database",
+  dbIdentifier: "prod-db-01",
+  engine: "mysql 8.0",
+  instanceClass: "db.t3.micro",
+  displayStatus: "active",
+  status: "available",
   tfManaged: false,
 };
 
 const createNodeProps = (data: RDSNodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'rds',
+  type: "rds",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -41,76 +41,76 @@ const createNodeProps = (data: RDSNodeData) => ({
   positionAbsoluteY: 0,
 });
 
-describe('RDSNode', () => {
-  it('renders the node label', () => {
+describe("RDSNode", () => {
+  it("renders the node label", () => {
     render(<RDSNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('prod-database')).toBeInTheDocument();
+    expect(screen.getByText("prod-database")).toBeInTheDocument();
   });
 
-  it('renders the engine', () => {
+  it("renders the engine", () => {
     render(<RDSNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('mysql 8.0')).toBeInTheDocument();
+    expect(screen.getByText("mysql 8.0")).toBeInTheDocument();
   });
 
-  it('renders the instance class', () => {
+  it("renders the instance class", () => {
     render(<RDSNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('db.t3.micro')).toBeInTheDocument();
+    expect(screen.getByText("db.t3.micro")).toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultData, label: "" };
     render(<RDSNode {...createNodeProps(data)} />);
-    expect(screen.getByText('RDS')).toBeInTheDocument();
+    expect(screen.getByText("RDS")).toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultData, tfManaged: true };
     render(<RDSNode {...createNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<RDSNode {...createNodeProps(defaultData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders with active status styling', () => {
+  it("renders with active status styling", () => {
     const { container } = render(<RDSNode {...createNodeProps(defaultData)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-500');
+    expect(nodeDiv.className).toContain("border-green-500");
   });
 
-  it('renders with inactive status styling', () => {
-    const data = { ...defaultData, displayStatus: 'inactive' as const };
+  it("renders with inactive status styling", () => {
+    const data = { ...defaultData, displayStatus: "inactive" as const };
     const { container } = render(<RDSNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-400');
+    expect(nodeDiv.className).toContain("border-gray-400");
   });
 
-  it('renders with transitioning status styling', () => {
-    const data = { ...defaultData, displayStatus: 'transitioning' as const };
+  it("renders with transitioning status styling", () => {
+    const data = { ...defaultData, displayStatus: "transitioning" as const };
     const { container } = render(<RDSNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-yellow-500');
+    expect(nodeDiv.className).toContain("border-yellow-500");
   });
 
-  it('renders with error status styling', () => {
-    const data = { ...defaultData, displayStatus: 'error' as const };
+  it("renders with error status styling", () => {
+    const data = { ...defaultData, displayStatus: "error" as const };
     const { container } = render(<RDSNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-red-500');
+    expect(nodeDiv.className).toContain("border-red-500");
   });
 
-  it('renders with unknown status styling', () => {
-    const data = { ...defaultData, displayStatus: 'unknown' as const };
+  it("renders with unknown status styling", () => {
+    const data = { ...defaultData, displayStatus: "unknown" as const };
     const { container } = render(<RDSNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-300');
+    expect(nodeDiv.className).toContain("border-gray-300");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<RDSNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/nodes/SubnetNode.test.tsx
+++ b/frontend/src/components/topology/nodes/SubnetNode.test.tsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { SubnetNode } from './SubnetNode';
-import type { SubnetNodeData } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SubnetNode } from "./SubnetNode";
+import type { SubnetNodeData } from "@/types/topology";
 
 // Mock react-flow
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   Handle: ({ type, position }: { type: string; position: string }) => (
     <div data-testid={`handle-${type}-${position}`} />
   ),
   Position: {
-    Top: 'top',
-    Bottom: 'bottom',
-    Left: 'left',
-    Right: 'right',
+    Top: "top",
+    Bottom: "bottom",
+    Left: "left",
+    Right: "right",
   },
 }));
 
 const defaultData: SubnetNodeData = {
-  type: 'subnet',
-  label: 'public-subnet-1',
-  subnetId: 'subnet-12345',
-  subnetType: 'public',
-  cidrBlock: '10.0.1.0/24',
-  availabilityZone: 'us-east-1a',
-  displayStatus: 'active',
+  type: "subnet",
+  label: "public-subnet-1",
+  subnetId: "subnet-12345",
+  subnetType: "public",
+  cidrBlock: "10.0.1.0/24",
+  availabilityZone: "us-east-1a",
+  displayStatus: "active",
   tfManaged: false,
 };
 
 const createNodeProps = (data: SubnetNodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'subnet',
+  type: "subnet",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -41,76 +41,78 @@ const createNodeProps = (data: SubnetNodeData) => ({
   positionAbsoluteY: 0,
 });
 
-describe('SubnetNode', () => {
-  it('renders the node label', () => {
+describe("SubnetNode", () => {
+  it("renders the node label", () => {
     render(<SubnetNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('public-subnet-1')).toBeInTheDocument();
+    expect(screen.getByText("public-subnet-1")).toBeInTheDocument();
   });
 
-  it('renders the CIDR block and availability zone', () => {
+  it("renders the CIDR block and availability zone", () => {
     render(<SubnetNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('10.0.1.0/24 | us-east-1a')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.0/24 | us-east-1a")).toBeInTheDocument();
   });
 
-  it('renders the subnet type badge', () => {
+  it("renders the subnet type badge", () => {
     render(<SubnetNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('public')).toBeInTheDocument();
+    expect(screen.getByText("public")).toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultData, label: "" };
     render(<SubnetNode {...createNodeProps(data)} />);
-    expect(screen.getByText('Subnet')).toBeInTheDocument();
+    expect(screen.getByText("Subnet")).toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultData, tfManaged: true };
     render(<SubnetNode {...createNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<SubnetNode {...createNodeProps(defaultData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders with public subnet styling', () => {
-    const { container } = render(<SubnetNode {...createNodeProps(defaultData)} />);
+  it("renders with public subnet styling", () => {
+    const { container } = render(
+      <SubnetNode {...createNodeProps(defaultData)} />,
+    );
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-400');
+    expect(nodeDiv.className).toContain("border-green-400");
   });
 
-  it('renders with private subnet styling', () => {
-    const data = { ...defaultData, subnetType: 'private' as const };
+  it("renders with private subnet styling", () => {
+    const data = { ...defaultData, subnetType: "private" as const };
     const { container } = render(<SubnetNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-blue-400');
+    expect(nodeDiv.className).toContain("border-blue-400");
   });
 
-  it('renders with unknown subnet styling', () => {
-    const data = { ...defaultData, subnetType: 'unknown' as const };
+  it("renders with unknown subnet styling", () => {
+    const data = { ...defaultData, subnetType: "unknown" as const };
     const { container } = render(<SubnetNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-300');
+    expect(nodeDiv.className).toContain("border-gray-300");
   });
 
-  it('renders private subnet type badge with correct styling', () => {
-    const data = { ...defaultData, subnetType: 'private' as const };
+  it("renders private subnet type badge with correct styling", () => {
+    const data = { ...defaultData, subnetType: "private" as const };
     render(<SubnetNode {...createNodeProps(data)} />);
-    const badge = screen.getByText('private');
-    expect(badge.className).toContain('bg-blue-100');
+    const badge = screen.getByText("private");
+    expect(badge.className).toContain("bg-blue-100");
   });
 
-  it('renders unknown subnet type badge with correct styling', () => {
-    const data = { ...defaultData, subnetType: 'unknown' as const };
+  it("renders unknown subnet type badge with correct styling", () => {
+    const data = { ...defaultData, subnetType: "unknown" as const };
     render(<SubnetNode {...createNodeProps(data)} />);
-    const badge = screen.getByText('unknown');
-    expect(badge.className).toContain('bg-gray-100');
+    const badge = screen.getByText("unknown");
+    expect(badge.className).toContain("bg-gray-100");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<SubnetNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/nodes/VPCNode.test.tsx
+++ b/frontend/src/components/topology/nodes/VPCNode.test.tsx
@@ -1,34 +1,34 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { VPCNode } from './VPCNode';
-import type { VPCNodeData } from '@/types/topology';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { VPCNode } from "./VPCNode";
+import type { VPCNodeData } from "@/types/topology";
 
 // Mock react-flow
-vi.mock('reactflow', () => ({
+vi.mock("reactflow", () => ({
   Handle: ({ type, position }: { type: string; position: string }) => (
     <div data-testid={`handle-${type}-${position}`} />
   ),
   Position: {
-    Top: 'top',
-    Bottom: 'bottom',
-    Left: 'left',
-    Right: 'right',
+    Top: "top",
+    Bottom: "bottom",
+    Left: "left",
+    Right: "right",
   },
 }));
 
 const defaultData: VPCNodeData = {
-  type: 'vpc',
-  label: 'main-vpc',
-  vpcId: 'vpc-12345',
-  cidrBlock: '10.0.0.0/16',
-  displayStatus: 'active',
+  type: "vpc",
+  label: "main-vpc",
+  vpcId: "vpc-12345",
+  cidrBlock: "10.0.0.0/16",
+  displayStatus: "active",
   tfManaged: false,
 };
 
 const createNodeProps = (data: VPCNodeData) => ({
-  id: 'test-node',
+  id: "test-node",
   data,
-  type: 'vpc',
+  type: "vpc",
   selected: false,
   isConnectable: true,
   xPos: 0,
@@ -39,76 +39,76 @@ const createNodeProps = (data: VPCNodeData) => ({
   positionAbsoluteY: 0,
 });
 
-describe('VPCNode', () => {
-  it('renders the node label', () => {
+describe("VPCNode", () => {
+  it("renders the node label", () => {
     render(<VPCNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('main-vpc')).toBeInTheDocument();
+    expect(screen.getByText("main-vpc")).toBeInTheDocument();
   });
 
-  it('renders the VPC ID', () => {
+  it("renders the VPC ID", () => {
     render(<VPCNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('vpc-12345')).toBeInTheDocument();
+    expect(screen.getByText("vpc-12345")).toBeInTheDocument();
   });
 
-  it('renders the CIDR block', () => {
+  it("renders the CIDR block", () => {
     render(<VPCNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByText('10.0.0.0/16')).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/16")).toBeInTheDocument();
   });
 
-  it('renders default label when no label provided', () => {
-    const data = { ...defaultData, label: '' };
+  it("renders default label when no label provided", () => {
+    const data = { ...defaultData, label: "" };
     render(<VPCNode {...createNodeProps(data)} />);
-    expect(screen.getByText('VPC')).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
   });
 
-  it('renders TF badge when terraform managed', () => {
+  it("renders TF badge when terraform managed", () => {
     const data = { ...defaultData, tfManaged: true };
     render(<VPCNode {...createNodeProps(data)} />);
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not render TF badge when not terraform managed', () => {
+  it("does not render TF badge when not terraform managed", () => {
     render(<VPCNode {...createNodeProps(defaultData)} />);
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 
-  it('renders with active status styling', () => {
+  it("renders with active status styling", () => {
     const { container } = render(<VPCNode {...createNodeProps(defaultData)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-green-500');
+    expect(nodeDiv.className).toContain("border-green-500");
   });
 
-  it('renders with inactive status styling', () => {
-    const data = { ...defaultData, displayStatus: 'inactive' as const };
+  it("renders with inactive status styling", () => {
+    const data = { ...defaultData, displayStatus: "inactive" as const };
     const { container } = render(<VPCNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-400');
+    expect(nodeDiv.className).toContain("border-gray-400");
   });
 
-  it('renders with transitioning status styling', () => {
-    const data = { ...defaultData, displayStatus: 'transitioning' as const };
+  it("renders with transitioning status styling", () => {
+    const data = { ...defaultData, displayStatus: "transitioning" as const };
     const { container } = render(<VPCNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-yellow-500');
+    expect(nodeDiv.className).toContain("border-yellow-500");
   });
 
-  it('renders with error status styling', () => {
-    const data = { ...defaultData, displayStatus: 'error' as const };
+  it("renders with error status styling", () => {
+    const data = { ...defaultData, displayStatus: "error" as const };
     const { container } = render(<VPCNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-red-500');
+    expect(nodeDiv.className).toContain("border-red-500");
   });
 
-  it('renders with unknown status styling', () => {
-    const data = { ...defaultData, displayStatus: 'unknown' as const };
+  it("renders with unknown status styling", () => {
+    const data = { ...defaultData, displayStatus: "unknown" as const };
     const { container } = render(<VPCNode {...createNodeProps(data)} />);
     const nodeDiv = container.firstChild as HTMLElement;
-    expect(nodeDiv.className).toContain('border-gray-300');
+    expect(nodeDiv.className).toContain("border-gray-300");
   });
 
-  it('renders handles for connections', () => {
+  it("renders handles for connections", () => {
     render(<VPCNode {...createNodeProps(defaultData)} />);
-    expect(screen.getByTestId('handle-target-top')).toBeInTheDocument();
-    expect(screen.getByTestId('handle-source-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId("handle-target-top")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-source-bottom")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/ElasticIPDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/ElasticIPDetailPanel.test.tsx
@@ -1,124 +1,161 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { ElasticIPDetailPanel } from './ElasticIPDetailPanel';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ElasticIPDetailPanel } from "./ElasticIPDetailPanel";
 
 const mockElasticIP = {
   id: 1,
-  allocation_id: 'eipalloc-123456',
-  name: 'Web Server EIP',
-  public_ip: '54.1.2.3',
-  private_ip: '10.0.1.100',
-  display_status: 'active' as const,
-  domain: 'vpc',
-  association_id: 'eipassoc-123',
-  instance_id: 'i-123',
+  allocation_id: "eipalloc-123456",
+  name: "Web Server EIP",
+  public_ip: "54.1.2.3",
+  private_ip: "10.0.1.100",
+  display_status: "active" as const,
+  domain: "vpc",
+  association_id: "eipassoc-123",
+  instance_id: "i-123",
   network_interface_id: null,
-  region_name: 'us-east-1',
+  region_name: "us-east-1",
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_eip.web',
-  updated_at: '2024-01-15T12:00:00Z',
-  created_at: '2024-01-01T00:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_eip.web",
+  updated_at: "2024-01-15T12:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
   is_deleted: false,
   deleted_at: null,
-  tags: { Environment: 'production' },
+  tags: { Environment: "production" },
 };
 
-describe('ElasticIPDetailPanel', () => {
+describe("ElasticIPDetailPanel", () => {
   const mockOnClose = vi.fn();
 
-  it('renders panel header', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('Elastic IP Details')).toBeInTheDocument();
+  it("renders panel header", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("Elastic IP Details")).toBeInTheDocument();
   });
 
-  it('renders Elastic IP name', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('Web Server EIP')).toBeInTheDocument();
+  it("renders Elastic IP name", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("Web Server EIP")).toBeInTheDocument();
   });
 
-  it('renders allocation ID', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('eipalloc-123456')).toBeInTheDocument();
+  it("renders allocation ID", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("eipalloc-123456")).toBeInTheDocument();
   });
 
-  it('renders public IP', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
+  it("renders public IP", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
   });
 
-  it('renders private IP', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
+  it("renders private IP", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
   });
 
-  it('renders domain badge', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
+  it("renders domain badge", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
     // Multiple "vpc" labels may exist (badge and detail row)
-    const vpcElements = screen.getAllByText('vpc');
+    const vpcElements = screen.getAllByText("vpc");
     expect(vpcElements.length).toBeGreaterThan(0);
   });
 
-  it('renders association status as Associated', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('Associated')).toBeInTheDocument();
+  it("renders association status as Associated", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("Associated")).toBeInTheDocument();
   });
 
-  it('renders association ID', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('eipassoc-123')).toBeInTheDocument();
+  it("renders association ID", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("eipassoc-123")).toBeInTheDocument();
   });
 
-  it('renders instance ID when associated with instance', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
+  it("renders instance ID when associated with instance", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
     // i-123 may appear in multiple places
-    const instanceIdElements = screen.getAllByText('i-123');
+    const instanceIdElements = screen.getAllByText("i-123");
     expect(instanceIdElements.length).toBeGreaterThan(0);
   });
 
-  it('renders terraform section when managed', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('aws_eip.web')).toBeInTheDocument();
+  it("renders terraform section when managed", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("aws_eip.web")).toBeInTheDocument();
   });
 
-  it('renders tags', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
-    expect(screen.getByText('production')).toBeInTheDocument();
+  it("renders tags", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
-    render(<ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />);
-    const closeButtons = screen.getAllByRole('button');
+  it("calls onClose when close button is clicked", () => {
+    render(
+      <ElasticIPDetailPanel elasticIP={mockElasticIP} onClose={mockOnClose} />,
+    );
+    const closeButtons = screen.getAllByRole("button");
     fireEvent.click(closeButtons[0]);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('shows Unassociated status when no association', () => {
-    const unassociatedEIP = { ...mockElasticIP, association_id: null, instance_id: null };
-    render(<ElasticIPDetailPanel elasticIP={unassociatedEIP} onClose={mockOnClose} />);
-    expect(screen.getByText('Unassociated')).toBeInTheDocument();
+  it("shows Unassociated status when no association", () => {
+    const unassociatedEIP = {
+      ...mockElasticIP,
+      association_id: null,
+      instance_id: null,
+    };
+    render(
+      <ElasticIPDetailPanel
+        elasticIP={unassociatedEIP}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("Unassociated")).toBeInTheDocument();
   });
 
-  it('renders network interface association type', () => {
+  it("renders network interface association type", () => {
     const eniEIP = {
       ...mockElasticIP,
       instance_id: null,
-      network_interface_id: 'eni-456',
+      network_interface_id: "eni-456",
     };
     render(<ElasticIPDetailPanel elasticIP={eniEIP} onClose={mockOnClose} />);
     // Multiple "Network Interface" elements may appear
-    const networkInterfaceElements = screen.getAllByText('Network Interface');
+    const networkInterfaceElements = screen.getAllByText("Network Interface");
     expect(networkInterfaceElements.length).toBeGreaterThan(0);
     // Multiple eni-456 may appear in different sections
-    const eniElements = screen.getAllByText('eni-456');
+    const eniElements = screen.getAllByText("eni-456");
     expect(eniElements.length).toBeGreaterThan(0);
   });
 
-  it('does not show terraform section when not managed', () => {
+  it("does not show terraform section when not managed", () => {
     const unmanagedEIP = { ...mockElasticIP, tf_managed: false };
-    render(<ElasticIPDetailPanel elasticIP={unmanagedEIP} onClose={mockOnClose} />);
-    expect(screen.queryByText('prod/terraform.tfstate')).not.toBeInTheDocument();
+    render(
+      <ElasticIPDetailPanel elasticIP={unmanagedEIP} onClose={mockOnClose} />,
+    );
+    expect(
+      screen.queryByText("prod/terraform.tfstate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/ElasticIPList.test.tsx
+++ b/frontend/src/components/vpc/ElasticIPList.test.tsx
@@ -1,46 +1,46 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { ElasticIPList } from './ElasticIPList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { ElasticIPList } from "./ElasticIPList";
 
 const mockElasticIPs = [
   {
-    allocation_id: 'eipalloc-123',
-    name: 'Web Server EIP',
-    public_ip: '54.1.2.3',
-    private_ip: '10.0.1.100',
-    display_status: 'active' as const,
-    domain: 'vpc',
-    association_id: 'eipassoc-123',
-    instance_id: 'i-123',
+    allocation_id: "eipalloc-123",
+    name: "Web Server EIP",
+    public_ip: "54.1.2.3",
+    private_ip: "10.0.1.100",
+    display_status: "active" as const,
+    domain: "vpc",
+    association_id: "eipassoc-123",
+    instance_id: "i-123",
     network_interface_id: null,
     tf_managed: true,
-    updated_at: '2024-01-15T12:00:00Z',
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    allocation_id: 'eipalloc-456',
-    name: 'Unused EIP',
-    public_ip: '54.1.2.4',
+    allocation_id: "eipalloc-456",
+    name: "Unused EIP",
+    public_ip: "54.1.2.4",
     private_ip: null,
-    display_status: 'inactive' as const,
-    domain: 'vpc',
+    display_status: "inactive" as const,
+    domain: "vpc",
     association_id: null,
     instance_id: null,
     network_interface_id: null,
     tf_managed: false,
-    updated_at: '2024-01-14T12:00:00Z',
+    updated_at: "2024-01-14T12:00:00Z",
   },
   {
-    allocation_id: 'eipalloc-789',
-    name: 'ENI EIP',
-    public_ip: '54.1.2.5',
-    private_ip: '10.0.2.100',
-    display_status: 'active' as const,
-    domain: 'vpc',
-    association_id: 'eipassoc-789',
+    allocation_id: "eipalloc-789",
+    name: "ENI EIP",
+    public_ip: "54.1.2.5",
+    private_ip: "10.0.2.100",
+    display_status: "active" as const,
+    domain: "vpc",
+    association_id: "eipassoc-789",
     instance_id: null,
-    network_interface_id: 'eni-123',
+    network_interface_id: "eni-123",
     tf_managed: true,
-    updated_at: '2024-01-13T12:00:00Z',
+    updated_at: "2024-01-13T12:00:00Z",
   },
 ];
 
@@ -48,7 +48,7 @@ let mockData = { data: mockElasticIPs, meta: { total: 3 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useElasticIPs: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -56,7 +56,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('ElasticIPList', () => {
+describe("ElasticIPList", () => {
   const mockOnFilterChange = vi.fn();
   const defaultProps = {
     filters: {},
@@ -70,100 +70,102 @@ describe('ElasticIPList', () => {
     mockError = null;
   });
 
-  it('renders Elastic IP count', () => {
+  it("renders Elastic IP count", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('3 Elastic IPs found')).toBeInTheDocument();
+    expect(screen.getByText("3 Elastic IPs found")).toBeInTheDocument();
   });
 
-  it('renders Elastic IP names', () => {
+  it("renders Elastic IP names", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('Web Server EIP')).toBeInTheDocument();
-    expect(screen.getByText('Unused EIP')).toBeInTheDocument();
-    expect(screen.getByText('ENI EIP')).toBeInTheDocument();
+    expect(screen.getByText("Web Server EIP")).toBeInTheDocument();
+    expect(screen.getByText("Unused EIP")).toBeInTheDocument();
+    expect(screen.getByText("ENI EIP")).toBeInTheDocument();
   });
 
-  it('renders allocation IDs', () => {
+  it("renders allocation IDs", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('eipalloc-123')).toBeInTheDocument();
-    expect(screen.getByText('eipalloc-456')).toBeInTheDocument();
-    expect(screen.getByText('eipalloc-789')).toBeInTheDocument();
+    expect(screen.getByText("eipalloc-123")).toBeInTheDocument();
+    expect(screen.getByText("eipalloc-456")).toBeInTheDocument();
+    expect(screen.getByText("eipalloc-789")).toBeInTheDocument();
   });
 
-  it('renders public IPs', () => {
+  it("renders public IPs", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
-    expect(screen.getByText('54.1.2.4')).toBeInTheDocument();
-    expect(screen.getByText('54.1.2.5')).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.4")).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.5")).toBeInTheDocument();
   });
 
-  it('renders private IPs when available', () => {
+  it("renders private IPs when available", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
-    expect(screen.getByText('10.0.2.100')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
+    expect(screen.getByText("10.0.2.100")).toBeInTheDocument();
   });
 
-  it('renders domain badges', () => {
+  it("renders domain badges", () => {
     render(<ElasticIPList {...defaultProps} />);
-    const domainBadges = screen.getAllByText('vpc');
+    const domainBadges = screen.getAllByText("vpc");
     expect(domainBadges.length).toBe(3);
   });
 
-  it('renders instance association', () => {
+  it("renders instance association", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('i-123')).toBeInTheDocument();
+    expect(screen.getByText("i-123")).toBeInTheDocument();
   });
 
-  it('renders network interface association', () => {
+  it("renders network interface association", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('eni-123')).toBeInTheDocument();
+    expect(screen.getByText("eni-123")).toBeInTheDocument();
   });
 
-  it('renders Unassociated for unassociated IPs', () => {
+  it("renders Unassociated for unassociated IPs", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('Unassociated')).toBeInTheDocument();
+    expect(screen.getByText("Unassociated")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<ElasticIPList {...defaultProps} />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Public IP')).toBeInTheDocument();
-    expect(screen.getByText('Private IP')).toBeInTheDocument();
-    expect(screen.getByText('Association')).toBeInTheDocument();
-    expect(screen.getByText('Domain')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Public IP")).toBeInTheDocument();
+    expect(screen.getByText("Private IP")).toBeInTheDocument();
+    expect(screen.getByText("Association")).toBeInTheDocument();
+    expect(screen.getByText("Domain")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<ElasticIPList {...defaultProps} />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('Error loading Elastic IPs')).toBeInTheDocument();
+    expect(screen.getByText("Error loading Elastic IPs")).toBeInTheDocument();
   });
 
-  it('shows empty state when no Elastic IPs', () => {
+  it("shows empty state when no Elastic IPs", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByText('No Elastic IPs found')).toBeInTheDocument();
+    expect(screen.getByText("No Elastic IPs found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<ElasticIPList {...defaultProps} />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/IGWDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/IGWDetailPanel.test.tsx
@@ -1,86 +1,88 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { IGWDetailPanel } from './IGWDetailPanel';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { IGWDetailPanel } from "./IGWDetailPanel";
 
 const mockIGW = {
   id: 1,
-  igw_id: 'igw-123456',
-  name: 'Main IGW',
-  vpc_id: 'vpc-123',
-  display_status: 'active' as const,
-  state: 'attached',
-  region_name: 'us-east-1',
+  igw_id: "igw-123456",
+  name: "Main IGW",
+  vpc_id: "vpc-123",
+  display_status: "active" as const,
+  state: "attached",
+  region_name: "us-east-1",
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_internet_gateway.main',
-  updated_at: '2024-01-15T12:00:00Z',
-  created_at: '2024-01-01T00:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_internet_gateway.main",
+  updated_at: "2024-01-15T12:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
   is_deleted: false,
   deleted_at: null,
-  tags: { Environment: 'production' },
+  tags: { Environment: "production" },
 };
 
-describe('IGWDetailPanel', () => {
+describe("IGWDetailPanel", () => {
   const mockOnClose = vi.fn();
 
-  it('renders panel header', () => {
+  it("renders panel header", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('Internet Gateway Details')).toBeInTheDocument();
+    expect(screen.getByText("Internet Gateway Details")).toBeInTheDocument();
   });
 
-  it('renders IGW name', () => {
+  it("renders IGW name", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('Main IGW')).toBeInTheDocument();
+    expect(screen.getByText("Main IGW")).toBeInTheDocument();
   });
 
-  it('renders IGW ID', () => {
+  it("renders IGW ID", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('igw-123456')).toBeInTheDocument();
+    expect(screen.getByText("igw-123456")).toBeInTheDocument();
   });
 
-  it('renders VPC ID when attached', () => {
+  it("renders VPC ID when attached", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
   });
 
-  it('renders state', () => {
+  it("renders state", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('attached')).toBeInTheDocument();
+    expect(screen.getByText("attached")).toBeInTheDocument();
   });
 
-  it('renders region', () => {
+  it("renders region", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('us-east-1')).toBeInTheDocument();
+    expect(screen.getByText("us-east-1")).toBeInTheDocument();
   });
 
-  it('renders terraform section when managed', () => {
+  it("renders terraform section when managed", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('aws_internet_gateway.main')).toBeInTheDocument();
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("aws_internet_gateway.main")).toBeInTheDocument();
   });
 
-  it('renders tags', () => {
+  it("renders tags", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
-    expect(screen.getByText('production')).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it("calls onClose when close button is clicked", () => {
     render(<IGWDetailPanel igw={mockIGW} onClose={mockOnClose} />);
-    const closeButtons = screen.getAllByRole('button');
+    const closeButtons = screen.getAllByRole("button");
     fireEvent.click(closeButtons[0]);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('shows Detached when no VPC is attached', () => {
+  it("shows Detached when no VPC is attached", () => {
     const detachedIGW = { ...mockIGW, vpc_id: null };
     render(<IGWDetailPanel igw={detachedIGW} onClose={mockOnClose} />);
-    expect(screen.getByText('Detached')).toBeInTheDocument();
+    expect(screen.getByText("Detached")).toBeInTheDocument();
   });
 
-  it('does not show terraform section when not managed', () => {
+  it("does not show terraform section when not managed", () => {
     const unmanagedIGW = { ...mockIGW, tf_managed: false };
     render(<IGWDetailPanel igw={unmanagedIGW} onClose={mockOnClose} />);
-    expect(screen.queryByText('prod/terraform.tfstate')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("prod/terraform.tfstate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/IGWList.test.tsx
+++ b/frontend/src/components/vpc/IGWList.test.tsx
@@ -1,25 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { IGWList } from './IGWList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { IGWList } from "./IGWList";
 
 const mockIGWs = [
   {
-    igw_id: 'igw-123',
-    name: 'Main IGW',
-    vpc_id: 'vpc-123',
-    display_status: 'active' as const,
-    state: 'attached',
+    igw_id: "igw-123",
+    name: "Main IGW",
+    vpc_id: "vpc-123",
+    display_status: "active" as const,
+    state: "attached",
     tf_managed: true,
-    updated_at: '2024-01-15T12:00:00Z',
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    igw_id: 'igw-456',
-    name: 'Secondary IGW',
+    igw_id: "igw-456",
+    name: "Secondary IGW",
     vpc_id: null,
-    display_status: 'inactive' as const,
-    state: 'detached',
+    display_status: "inactive" as const,
+    state: "detached",
     tf_managed: false,
-    updated_at: '2024-01-14T12:00:00Z',
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -27,7 +27,7 @@ let mockData = { data: mockIGWs, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useInternetGateways: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -35,7 +35,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('IGWList', () => {
+describe("IGWList", () => {
   const mockOnFilterChange = vi.fn();
   const defaultProps = {
     filters: {},
@@ -49,78 +49,82 @@ describe('IGWList', () => {
     mockError = null;
   });
 
-  it('renders IGW count', () => {
+  it("renders IGW count", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('2 Internet Gateways found')).toBeInTheDocument();
+    expect(screen.getByText("2 Internet Gateways found")).toBeInTheDocument();
   });
 
-  it('renders IGW names', () => {
+  it("renders IGW names", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('Main IGW')).toBeInTheDocument();
-    expect(screen.getByText('Secondary IGW')).toBeInTheDocument();
+    expect(screen.getByText("Main IGW")).toBeInTheDocument();
+    expect(screen.getByText("Secondary IGW")).toBeInTheDocument();
   });
 
-  it('renders IGW IDs', () => {
+  it("renders IGW IDs", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('igw-123')).toBeInTheDocument();
-    expect(screen.getByText('igw-456')).toBeInTheDocument();
+    expect(screen.getByText("igw-123")).toBeInTheDocument();
+    expect(screen.getByText("igw-456")).toBeInTheDocument();
   });
 
-  it('renders VPC ID when attached', () => {
+  it("renders VPC ID when attached", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
   });
 
-  it('renders Detached when no VPC', () => {
+  it("renders Detached when no VPC", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('Detached')).toBeInTheDocument();
+    expect(screen.getByText("Detached")).toBeInTheDocument();
   });
 
-  it('renders state', () => {
+  it("renders state", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('attached')).toBeInTheDocument();
-    expect(screen.getByText('detached')).toBeInTheDocument();
+    expect(screen.getByText("attached")).toBeInTheDocument();
+    expect(screen.getByText("detached")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<IGWList {...defaultProps} />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('State')).toBeInTheDocument();
-    expect(screen.getByText('VPC')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("State")).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<IGWList {...defaultProps} />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('Error loading Internet Gateways')).toBeInTheDocument();
+    expect(
+      screen.getByText("Error loading Internet Gateways"),
+    ).toBeInTheDocument();
   });
 
-  it('shows empty state when no IGWs', () => {
+  it("shows empty state when no IGWs", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByText('No Internet Gateways found')).toBeInTheDocument();
+    expect(screen.getByText("No Internet Gateways found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<IGWList {...defaultProps} />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/NATGatewayDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/NATGatewayDetailPanel.test.tsx
@@ -1,108 +1,177 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { NATGatewayDetailPanel } from './NATGatewayDetailPanel';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { NATGatewayDetailPanel } from "./NATGatewayDetailPanel";
 
 const mockNATGateway = {
   id: 1,
-  nat_gateway_id: 'nat-123456',
-  name: 'NAT Gateway 1',
-  vpc_id: 'vpc-123',
-  subnet_id: 'subnet-123',
-  display_status: 'active' as const,
-  state: 'available',
-  connectivity_type: 'public' as const,
-  primary_public_ip: '54.1.2.3',
-  primary_private_ip: '10.0.1.100',
-  allocation_id: 'eipalloc-123',
-  network_interface_id: 'eni-123',
-  region_name: 'us-east-1',
+  nat_gateway_id: "nat-123456",
+  name: "NAT Gateway 1",
+  vpc_id: "vpc-123",
+  subnet_id: "subnet-123",
+  display_status: "active" as const,
+  state: "available",
+  connectivity_type: "public" as const,
+  primary_public_ip: "54.1.2.3",
+  primary_private_ip: "10.0.1.100",
+  allocation_id: "eipalloc-123",
+  network_interface_id: "eni-123",
+  region_name: "us-east-1",
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_nat_gateway.main',
-  updated_at: '2024-01-15T12:00:00Z',
-  created_at: '2024-01-01T00:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_nat_gateway.main",
+  updated_at: "2024-01-15T12:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
   is_deleted: false,
   deleted_at: null,
-  tags: { Environment: 'production' },
+  tags: { Environment: "production" },
 };
 
-describe('NATGatewayDetailPanel', () => {
+describe("NATGatewayDetailPanel", () => {
   const mockOnClose = vi.fn();
 
-  it('renders panel header', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('NAT Gateway Details')).toBeInTheDocument();
+  it("renders panel header", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("NAT Gateway Details")).toBeInTheDocument();
   });
 
-  it('renders NAT gateway name', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('NAT Gateway 1')).toBeInTheDocument();
+  it("renders NAT gateway name", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("NAT Gateway 1")).toBeInTheDocument();
   });
 
-  it('renders NAT gateway ID', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('nat-123456')).toBeInTheDocument();
+  it("renders NAT gateway ID", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("nat-123456")).toBeInTheDocument();
   });
 
-  it('renders VPC ID', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
+  it("renders VPC ID", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
   });
 
-  it('renders subnet ID', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('subnet-123')).toBeInTheDocument();
+  it("renders subnet ID", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("subnet-123")).toBeInTheDocument();
   });
 
-  it('renders connectivity type', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
+  it("renders connectivity type", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
     // Multiple "public" labels may exist (badge and detail row)
-    const publicElements = screen.getAllByText('public');
+    const publicElements = screen.getAllByText("public");
     expect(publicElements.length).toBeGreaterThan(0);
   });
 
-  it('renders public IP', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
+  it("renders public IP", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
   });
 
-  it('renders private IP', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
+  it("renders private IP", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
   });
 
-  it('renders allocation ID', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('eipalloc-123')).toBeInTheDocument();
+  it("renders allocation ID", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("eipalloc-123")).toBeInTheDocument();
   });
 
-  it('renders network interface ID', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('eni-123')).toBeInTheDocument();
+  it("renders network interface ID", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("eni-123")).toBeInTheDocument();
   });
 
-  it('renders terraform section when managed', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('aws_nat_gateway.main')).toBeInTheDocument();
+  it("renders terraform section when managed", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("aws_nat_gateway.main")).toBeInTheDocument();
   });
 
-  it('renders tags', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
-    expect(screen.getByText('production')).toBeInTheDocument();
+  it("renders tags", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
-    render(<NATGatewayDetailPanel natGateway={mockNATGateway} onClose={mockOnClose} />);
-    const closeButtons = screen.getAllByRole('button');
+  it("calls onClose when close button is clicked", () => {
+    render(
+      <NATGatewayDetailPanel
+        natGateway={mockNATGateway}
+        onClose={mockOnClose}
+      />,
+    );
+    const closeButtons = screen.getAllByRole("button");
     fireEvent.click(closeButtons[0]);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('does not show terraform section when not managed', () => {
+  it("does not show terraform section when not managed", () => {
     const unmanagedNAT = { ...mockNATGateway, tf_managed: false };
-    render(<NATGatewayDetailPanel natGateway={unmanagedNAT} onClose={mockOnClose} />);
-    expect(screen.queryByText('prod/terraform.tfstate')).not.toBeInTheDocument();
+    render(
+      <NATGatewayDetailPanel natGateway={unmanagedNAT} onClose={mockOnClose} />,
+    );
+    expect(
+      screen.queryByText("prod/terraform.tfstate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/NATGatewayList.test.tsx
+++ b/frontend/src/components/vpc/NATGatewayList.test.tsx
@@ -1,33 +1,33 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { NATGatewayList } from './NATGatewayList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { NATGatewayList } from "./NATGatewayList";
 
 const mockNATGateways = [
   {
-    nat_gateway_id: 'nat-123',
-    name: 'NAT Gateway 1',
-    vpc_id: 'vpc-123',
-    subnet_id: 'subnet-123',
-    display_status: 'active' as const,
-    connectivity_type: 'public',
-    primary_public_ip: '54.1.2.3',
-    primary_private_ip: '10.0.1.100',
+    nat_gateway_id: "nat-123",
+    name: "NAT Gateway 1",
+    vpc_id: "vpc-123",
+    subnet_id: "subnet-123",
+    display_status: "active" as const,
+    connectivity_type: "public",
+    primary_public_ip: "54.1.2.3",
+    primary_private_ip: "10.0.1.100",
     tf_managed: true,
-    state: 'available',
-    updated_at: '2024-01-15T12:00:00Z',
+    state: "available",
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    nat_gateway_id: 'nat-456',
-    name: 'NAT Gateway 2',
-    vpc_id: 'vpc-456',
-    subnet_id: 'subnet-456',
-    display_status: 'active' as const,
-    connectivity_type: 'private',
+    nat_gateway_id: "nat-456",
+    name: "NAT Gateway 2",
+    vpc_id: "vpc-456",
+    subnet_id: "subnet-456",
+    display_status: "active" as const,
+    connectivity_type: "private",
     primary_public_ip: null,
-    primary_private_ip: '10.0.2.100',
+    primary_private_ip: "10.0.2.100",
     tf_managed: false,
-    state: 'available',
-    updated_at: '2024-01-14T12:00:00Z',
+    state: "available",
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -35,7 +35,7 @@ let mockData = { data: mockNATGateways, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useNATGateways: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -43,7 +43,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('NATGatewayList', () => {
+describe("NATGatewayList", () => {
   const mockOnFilterChange = vi.fn();
   const defaultProps = {
     filters: {},
@@ -57,100 +57,102 @@ describe('NATGatewayList', () => {
     mockError = null;
   });
 
-  it('renders NAT Gateway count', () => {
+  it("renders NAT Gateway count", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('2 NAT Gateways found')).toBeInTheDocument();
+    expect(screen.getByText("2 NAT Gateways found")).toBeInTheDocument();
   });
 
-  it('renders NAT Gateway names', () => {
+  it("renders NAT Gateway names", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('NAT Gateway 1')).toBeInTheDocument();
-    expect(screen.getByText('NAT Gateway 2')).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateway 1")).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateway 2")).toBeInTheDocument();
   });
 
-  it('renders NAT Gateway IDs', () => {
+  it("renders NAT Gateway IDs", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('nat-123')).toBeInTheDocument();
-    expect(screen.getByText('nat-456')).toBeInTheDocument();
+    expect(screen.getByText("nat-123")).toBeInTheDocument();
+    expect(screen.getByText("nat-456")).toBeInTheDocument();
   });
 
-  it('renders VPC IDs', () => {
+  it("renders VPC IDs", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
-    expect(screen.getByText('vpc-456')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
+    expect(screen.getByText("vpc-456")).toBeInTheDocument();
   });
 
-  it('renders subnet IDs', () => {
+  it("renders subnet IDs", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('subnet-123')).toBeInTheDocument();
-    expect(screen.getByText('subnet-456')).toBeInTheDocument();
+    expect(screen.getByText("subnet-123")).toBeInTheDocument();
+    expect(screen.getByText("subnet-456")).toBeInTheDocument();
   });
 
-  it('renders connectivity types', () => {
+  it("renders connectivity types", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('public')).toBeInTheDocument();
-    expect(screen.getByText('private')).toBeInTheDocument();
+    expect(screen.getByText("public")).toBeInTheDocument();
+    expect(screen.getByText("private")).toBeInTheDocument();
   });
 
-  it('renders public IPs when available', () => {
+  it("renders public IPs when available", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
   });
 
-  it('renders dash when no public IP', () => {
+  it("renders dash when no public IP", () => {
     render(<NATGatewayList {...defaultProps} />);
-    const dashes = screen.getAllByText('-');
+    const dashes = screen.getAllByText("-");
     expect(dashes.length).toBeGreaterThan(0);
   });
 
-  it('renders private IPs', () => {
+  it("renders private IPs", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
-    expect(screen.getByText('10.0.2.100')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
+    expect(screen.getByText("10.0.2.100")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<NATGatewayList {...defaultProps} />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Type')).toBeInTheDocument();
-    expect(screen.getByText('VPC')).toBeInTheDocument();
-    expect(screen.getByText('Subnet')).toBeInTheDocument();
-    expect(screen.getByText('Public IP')).toBeInTheDocument();
-    expect(screen.getByText('Private IP')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
+    expect(screen.getByText("Subnet")).toBeInTheDocument();
+    expect(screen.getByText("Public IP")).toBeInTheDocument();
+    expect(screen.getByText("Private IP")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<NATGatewayList {...defaultProps} />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('Error loading NAT Gateways')).toBeInTheDocument();
+    expect(screen.getByText("Error loading NAT Gateways")).toBeInTheDocument();
   });
 
-  it('shows empty state when no NAT Gateways', () => {
+  it("shows empty state when no NAT Gateways", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByText('No NAT Gateways found')).toBeInTheDocument();
+    expect(screen.getByText("No NAT Gateways found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<NATGatewayList {...defaultProps} />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/SubnetDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/SubnetDetailPanel.test.tsx
@@ -1,106 +1,110 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { SubnetDetailPanel } from './SubnetDetailPanel';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { SubnetDetailPanel } from "./SubnetDetailPanel";
 
 const mockSubnet = {
   id: 1,
-  subnet_id: 'subnet-123456',
-  vpc_id: 'vpc-123',
-  name: 'Public Subnet 1',
-  cidr_block: '10.0.1.0/24',
-  availability_zone: 'us-east-1a',
-  subnet_type: 'public' as const,
-  display_status: 'active' as const,
-  state: 'available',
-  region_name: 'us-east-1',
+  subnet_id: "subnet-123456",
+  vpc_id: "vpc-123",
+  name: "Public Subnet 1",
+  cidr_block: "10.0.1.0/24",
+  availability_zone: "us-east-1a",
+  subnet_type: "public" as const,
+  display_status: "active" as const,
+  state: "available",
+  region_name: "us-east-1",
   available_ip_count: 251,
   map_public_ip_on_launch: true,
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_subnet.public',
-  updated_at: '2024-01-15T12:00:00Z',
-  created_at: '2024-01-01T00:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_subnet.public",
+  updated_at: "2024-01-15T12:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
   is_deleted: false,
   deleted_at: null,
-  tags: { Environment: 'production' },
+  tags: { Environment: "production" },
 };
 
-describe('SubnetDetailPanel', () => {
+describe("SubnetDetailPanel", () => {
   const mockOnClose = vi.fn();
 
-  it('renders panel header', () => {
+  it("renders panel header", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('Subnet Details')).toBeInTheDocument();
+    expect(screen.getByText("Subnet Details")).toBeInTheDocument();
   });
 
-  it('renders subnet name', () => {
+  it("renders subnet name", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('Public Subnet 1')).toBeInTheDocument();
+    expect(screen.getByText("Public Subnet 1")).toBeInTheDocument();
   });
 
-  it('renders subnet ID', () => {
+  it("renders subnet ID", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('subnet-123456')).toBeInTheDocument();
+    expect(screen.getByText("subnet-123456")).toBeInTheDocument();
   });
 
-  it('renders CIDR block', () => {
+  it("renders CIDR block", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('10.0.1.0/24')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.0/24")).toBeInTheDocument();
   });
 
-  it('renders VPC ID', () => {
+  it("renders VPC ID", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
   });
 
-  it('renders availability zone', () => {
+  it("renders availability zone", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('us-east-1a')).toBeInTheDocument();
+    expect(screen.getByText("us-east-1a")).toBeInTheDocument();
   });
 
-  it('renders available IP count', () => {
+  it("renders available IP count", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('251')).toBeInTheDocument();
+    expect(screen.getByText("251")).toBeInTheDocument();
   });
 
-  it('renders subnet type badge', () => {
+  it("renders subnet type badge", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
     // Multiple "Public" badges may appear
-    const publicBadges = screen.getAllByText('Public');
+    const publicBadges = screen.getAllByText("Public");
     expect(publicBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders auto-assign public IP status', () => {
+  it("renders auto-assign public IP status", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
     // "Enabled" appears for auto-assign public IP
-    const enabledElements = screen.getAllByText('Enabled');
+    const enabledElements = screen.getAllByText("Enabled");
     expect(enabledElements.length).toBeGreaterThan(0);
   });
 
-  it('renders terraform section when managed', () => {
+  it("renders terraform section when managed", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('aws_subnet.public')).toBeInTheDocument();
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("aws_subnet.public")).toBeInTheDocument();
   });
 
-  it('renders tags', () => {
+  it("renders tags", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
     // "production" may appear multiple times
-    const productionElements = screen.getAllByText('production');
+    const productionElements = screen.getAllByText("production");
     expect(productionElements.length).toBeGreaterThan(0);
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it("calls onClose when close button is clicked", () => {
     render(<SubnetDetailPanel subnet={mockSubnet} onClose={mockOnClose} />);
-    const closeButtons = screen.getAllByRole('button');
+    const closeButtons = screen.getAllByRole("button");
     fireEvent.click(closeButtons[0]);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('does not show terraform section when not managed', () => {
+  it("does not show terraform section when not managed", () => {
     const unmanagedSubnet = { ...mockSubnet, tf_managed: false };
-    render(<SubnetDetailPanel subnet={unmanagedSubnet} onClose={mockOnClose} />);
-    expect(screen.queryByText('prod/terraform.tfstate')).not.toBeInTheDocument();
+    render(
+      <SubnetDetailPanel subnet={unmanagedSubnet} onClose={mockOnClose} />,
+    );
+    expect(
+      screen.queryByText("prod/terraform.tfstate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/SubnetList.test.tsx
+++ b/frontend/src/components/vpc/SubnetList.test.tsx
@@ -1,37 +1,37 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { SubnetList } from './SubnetList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SubnetList } from "./SubnetList";
 
 const mockSubnets = [
   {
-    subnet_id: 'subnet-123',
-    vpc_id: 'vpc-123',
-    name: 'Public Subnet 1',
-    cidr_block: '10.0.1.0/24',
-    availability_zone: 'us-east-1a',
-    subnet_type: 'public' as const,
-    display_status: 'active' as const,
+    subnet_id: "subnet-123",
+    vpc_id: "vpc-123",
+    name: "Public Subnet 1",
+    cidr_block: "10.0.1.0/24",
+    availability_zone: "us-east-1a",
+    subnet_type: "public" as const,
+    display_status: "active" as const,
     available_ip_count: 251,
     tf_managed: true,
-    state: 'available',
+    state: "available",
     map_public_ip_on_launch: true,
     default_for_az: false,
-    updated_at: '2024-01-15T12:00:00Z',
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    subnet_id: 'subnet-456',
-    vpc_id: 'vpc-123',
-    name: 'Private Subnet 1',
-    cidr_block: '10.0.2.0/24',
-    availability_zone: 'us-east-1b',
-    subnet_type: 'private' as const,
-    display_status: 'active' as const,
+    subnet_id: "subnet-456",
+    vpc_id: "vpc-123",
+    name: "Private Subnet 1",
+    cidr_block: "10.0.2.0/24",
+    availability_zone: "us-east-1b",
+    subnet_type: "private" as const,
+    display_status: "active" as const,
     available_ip_count: 250,
     tf_managed: false,
-    state: 'available',
+    state: "available",
     map_public_ip_on_launch: false,
     default_for_az: false,
-    updated_at: '2024-01-14T12:00:00Z',
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -39,7 +39,7 @@ let mockData = { data: mockSubnets, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useSubnets: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -47,7 +47,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('SubnetList', () => {
+describe("SubnetList", () => {
   const mockOnFilterChange = vi.fn();
   const defaultProps = {
     filters: {},
@@ -61,95 +61,97 @@ describe('SubnetList', () => {
     mockError = null;
   });
 
-  it('renders subnet count', () => {
+  it("renders subnet count", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('2 Subnets found')).toBeInTheDocument();
+    expect(screen.getByText("2 Subnets found")).toBeInTheDocument();
   });
 
-  it('renders subnet names', () => {
+  it("renders subnet names", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('Public Subnet 1')).toBeInTheDocument();
-    expect(screen.getByText('Private Subnet 1')).toBeInTheDocument();
+    expect(screen.getByText("Public Subnet 1")).toBeInTheDocument();
+    expect(screen.getByText("Private Subnet 1")).toBeInTheDocument();
   });
 
-  it('renders subnet IDs', () => {
+  it("renders subnet IDs", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('subnet-123')).toBeInTheDocument();
-    expect(screen.getByText('subnet-456')).toBeInTheDocument();
+    expect(screen.getByText("subnet-123")).toBeInTheDocument();
+    expect(screen.getByText("subnet-456")).toBeInTheDocument();
   });
 
-  it('renders CIDR blocks', () => {
+  it("renders CIDR blocks", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('10.0.1.0/24')).toBeInTheDocument();
-    expect(screen.getByText('10.0.2.0/24')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.0/24")).toBeInTheDocument();
+    expect(screen.getByText("10.0.2.0/24")).toBeInTheDocument();
   });
 
-  it('renders VPC IDs', () => {
+  it("renders VPC IDs", () => {
     render(<SubnetList {...defaultProps} />);
-    const vpcIds = screen.getAllByText('vpc-123');
+    const vpcIds = screen.getAllByText("vpc-123");
     expect(vpcIds.length).toBe(2);
   });
 
-  it('renders availability zones', () => {
+  it("renders availability zones", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('us-east-1a')).toBeInTheDocument();
-    expect(screen.getByText('us-east-1b')).toBeInTheDocument();
+    expect(screen.getByText("us-east-1a")).toBeInTheDocument();
+    expect(screen.getByText("us-east-1b")).toBeInTheDocument();
   });
 
-  it('renders available IP count', () => {
+  it("renders available IP count", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('251')).toBeInTheDocument();
-    expect(screen.getByText('250')).toBeInTheDocument();
+    expect(screen.getByText("251")).toBeInTheDocument();
+    expect(screen.getByText("250")).toBeInTheDocument();
   });
 
-  it('renders subnet type badges', () => {
+  it("renders subnet type badges", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('Public')).toBeInTheDocument();
-    expect(screen.getByText('Private')).toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<SubnetList {...defaultProps} />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Type')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('CIDR Block')).toBeInTheDocument();
-    expect(screen.getByText('VPC')).toBeInTheDocument();
-    expect(screen.getByText('Availability Zone')).toBeInTheDocument();
-    expect(screen.getByText('Available IPs')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("CIDR Block")).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
+    expect(screen.getByText("Availability Zone")).toBeInTheDocument();
+    expect(screen.getByText("Available IPs")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<SubnetList {...defaultProps} />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('Error loading Subnets')).toBeInTheDocument();
+    expect(screen.getByText("Error loading Subnets")).toBeInTheDocument();
   });
 
-  it('shows empty state when no subnets', () => {
+  it("shows empty state when no subnets", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByText('No Subnets found')).toBeInTheDocument();
+    expect(screen.getByText("No Subnets found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<SubnetList {...defaultProps} />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/SubnetTypeBadge.test.tsx
+++ b/frontend/src/components/vpc/SubnetTypeBadge.test.tsx
@@ -1,52 +1,52 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { SubnetTypeBadge } from './SubnetTypeBadge';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SubnetTypeBadge } from "./SubnetTypeBadge";
 
-describe('SubnetTypeBadge', () => {
-  it('renders public type correctly', () => {
+describe("SubnetTypeBadge", () => {
+  it("renders public type correctly", () => {
     render(<SubnetTypeBadge type="public" />);
-    expect(screen.getByText('Public')).toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
   });
 
-  it('renders private type correctly', () => {
+  it("renders private type correctly", () => {
     render(<SubnetTypeBadge type="private" />);
-    expect(screen.getByText('Private')).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
   });
 
-  it('renders unknown type correctly', () => {
+  it("renders unknown type correctly", () => {
     render(<SubnetTypeBadge type="unknown" />);
-    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
 
-  it('applies public styling', () => {
+  it("applies public styling", () => {
     render(<SubnetTypeBadge type="public" />);
-    const badge = screen.getByText('Public');
-    expect(badge).toHaveClass('bg-blue-100');
-    expect(badge).toHaveClass('text-blue-800');
+    const badge = screen.getByText("Public");
+    expect(badge).toHaveClass("bg-blue-100");
+    expect(badge).toHaveClass("text-blue-800");
   });
 
-  it('applies private styling', () => {
+  it("applies private styling", () => {
     render(<SubnetTypeBadge type="private" />);
-    const badge = screen.getByText('Private');
-    expect(badge).toHaveClass('bg-gray-100');
-    expect(badge).toHaveClass('text-gray-800');
+    const badge = screen.getByText("Private");
+    expect(badge).toHaveClass("bg-gray-100");
+    expect(badge).toHaveClass("text-gray-800");
   });
 
-  it('applies unknown styling', () => {
+  it("applies unknown styling", () => {
     render(<SubnetTypeBadge type="unknown" />);
-    const badge = screen.getByText('Unknown');
-    expect(badge).toHaveClass('bg-yellow-100');
-    expect(badge).toHaveClass('text-yellow-800');
+    const badge = screen.getByText("Unknown");
+    expect(badge).toHaveClass("bg-yellow-100");
+    expect(badge).toHaveClass("text-yellow-800");
   });
 
-  it('capitalizes first letter', () => {
+  it("capitalizes first letter", () => {
     render(<SubnetTypeBadge type="public" />);
-    expect(screen.getByText('Public')).toBeInTheDocument();
-    expect(screen.queryByText('public')).not.toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.queryByText("public")).not.toBeInTheDocument();
   });
 
-  it('renders as span element', () => {
+  it("renders as span element", () => {
     const { container } = render(<SubnetTypeBadge type="public" />);
-    expect(container.querySelector('span')).toBeInTheDocument();
+    expect(container.querySelector("span")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/VPCDetailPanel.test.tsx
+++ b/frontend/src/components/vpc/VPCDetailPanel.test.tsx
@@ -1,114 +1,116 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { VPCDetailPanel } from './VPCDetailPanel';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { VPCDetailPanel } from "./VPCDetailPanel";
 
 const mockVPC = {
   id: 1,
-  vpc_id: 'vpc-123456',
-  name: 'Production VPC',
-  cidr_block: '10.0.0.0/16',
-  display_status: 'active' as const,
-  state: 'available',
-  region_name: 'us-east-1',
+  vpc_id: "vpc-123456",
+  name: "Production VPC",
+  cidr_block: "10.0.0.0/16",
+  display_status: "active" as const,
+  state: "available",
+  region_name: "us-east-1",
   is_default: false,
   enable_dns_support: true,
   enable_dns_hostnames: true,
   tf_managed: true,
-  tf_state_source: 'prod/terraform.tfstate',
-  tf_resource_address: 'aws_vpc.main',
-  updated_at: '2024-01-15T12:00:00Z',
-  created_at: '2024-01-01T00:00:00Z',
+  tf_state_source: "prod/terraform.tfstate",
+  tf_resource_address: "aws_vpc.main",
+  updated_at: "2024-01-15T12:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
   is_deleted: false,
   deleted_at: null,
-  tags: { Environment: 'production', Project: 'main' },
+  tags: { Environment: "production", Project: "main" },
 };
 
-describe('VPCDetailPanel', () => {
+describe("VPCDetailPanel", () => {
   const mockOnClose = vi.fn();
 
-  it('renders panel header', () => {
+  it("renders panel header", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('VPC Details')).toBeInTheDocument();
+    expect(screen.getByText("VPC Details")).toBeInTheDocument();
   });
 
-  it('renders VPC name', () => {
+  it("renders VPC name", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('Production VPC')).toBeInTheDocument();
+    expect(screen.getByText("Production VPC")).toBeInTheDocument();
   });
 
-  it('renders VPC ID', () => {
+  it("renders VPC ID", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('vpc-123456')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123456")).toBeInTheDocument();
   });
 
-  it('renders CIDR block', () => {
+  it("renders CIDR block", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('10.0.0.0/16')).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/16")).toBeInTheDocument();
   });
 
-  it('renders state', () => {
+  it("renders state", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('available')).toBeInTheDocument();
+    expect(screen.getByText("available")).toBeInTheDocument();
   });
 
-  it('renders region', () => {
+  it("renders region", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('us-east-1')).toBeInTheDocument();
+    expect(screen.getByText("us-east-1")).toBeInTheDocument();
   });
 
-  it('renders DNS configuration', () => {
+  it("renders DNS configuration", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
     // Two "Enabled" labels for DNS Support and DNS Hostnames
-    const enabledElements = screen.getAllByText('Enabled');
+    const enabledElements = screen.getAllByText("Enabled");
     expect(enabledElements.length).toBe(2);
   });
 
-  it('renders terraform section when managed', () => {
+  it("renders terraform section when managed", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('aws_vpc.main')).toBeInTheDocument();
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("aws_vpc.main")).toBeInTheDocument();
   });
 
-  it('renders tags', () => {
+  it("renders tags", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
     // "production" may appear multiple times
-    const productionElements = screen.getAllByText('production');
+    const productionElements = screen.getAllByText("production");
     expect(productionElements.length).toBeGreaterThan(0);
-    expect(screen.getByText('Project')).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
     // "main" may appear in multiple places
-    const mainElements = screen.getAllByText('main');
+    const mainElements = screen.getAllByText("main");
     expect(mainElements.length).toBeGreaterThan(0);
   });
 
-  it('renders status badge', () => {
+  it("renders status badge", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it('renders terraform badge', () => {
+  it("renders terraform badge", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    expect(screen.getByText('Managed')).toBeInTheDocument();
+    expect(screen.getByText("Managed")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it("calls onClose when close button is clicked", () => {
     render(<VPCDetailPanel vpc={mockVPC} onClose={mockOnClose} />);
-    const closeButtons = screen.getAllByRole('button');
+    const closeButtons = screen.getAllByRole("button");
     fireEvent.click(closeButtons[0]);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('shows Default VPC badge when is_default is true', () => {
+  it("shows Default VPC badge when is_default is true", () => {
     const defaultVPC = { ...mockVPC, is_default: true };
     render(<VPCDetailPanel vpc={defaultVPC} onClose={mockOnClose} />);
     // Multiple "Default VPC" elements may appear (badge and detail row)
-    const defaultVpcElements = screen.getAllByText('Default VPC');
+    const defaultVpcElements = screen.getAllByText("Default VPC");
     expect(defaultVpcElements.length).toBeGreaterThan(0);
   });
 
-  it('does not show terraform section when not managed', () => {
+  it("does not show terraform section when not managed", () => {
     const unmanagedVPC = { ...mockVPC, tf_managed: false };
     render(<VPCDetailPanel vpc={unmanagedVPC} onClose={mockOnClose} />);
-    expect(screen.queryByText('prod/terraform.tfstate')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("prod/terraform.tfstate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/VPCList.test.tsx
+++ b/frontend/src/components/vpc/VPCList.test.tsx
@@ -1,33 +1,33 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { VPCList } from './VPCList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { VPCList } from "./VPCList";
 
 const mockVPCs = [
   {
-    vpc_id: 'vpc-123',
-    name: 'Production VPC',
-    cidr_block: '10.0.0.0/16',
-    display_status: 'active' as const,
+    vpc_id: "vpc-123",
+    name: "Production VPC",
+    cidr_block: "10.0.0.0/16",
+    display_status: "active" as const,
     is_default: false,
     enable_dns_support: true,
     enable_dns_hostnames: true,
     tf_managed: true,
-    state: 'available',
-    instance_tenancy: 'default',
-    updated_at: '2024-01-15T12:00:00Z',
+    state: "available",
+    instance_tenancy: "default",
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    vpc_id: 'vpc-456',
-    name: 'Development VPC',
-    cidr_block: '172.16.0.0/16',
-    display_status: 'active' as const,
+    vpc_id: "vpc-456",
+    name: "Development VPC",
+    cidr_block: "172.16.0.0/16",
+    display_status: "active" as const,
     is_default: true,
     enable_dns_support: false,
     enable_dns_hostnames: false,
     tf_managed: false,
-    state: 'available',
-    instance_tenancy: 'default',
-    updated_at: '2024-01-14T12:00:00Z',
+    state: "available",
+    instance_tenancy: "default",
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -35,7 +35,7 @@ let mockData = { data: mockVPCs, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useVPCs: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -43,7 +43,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('VPCList', () => {
+describe("VPCList", () => {
   const mockOnFilterChange = vi.fn();
   const defaultProps = {
     filters: {},
@@ -57,81 +57,83 @@ describe('VPCList', () => {
     mockError = null;
   });
 
-  it('renders VPC count', () => {
+  it("renders VPC count", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('2 VPCs found')).toBeInTheDocument();
+    expect(screen.getByText("2 VPCs found")).toBeInTheDocument();
   });
 
-  it('renders VPC names', () => {
+  it("renders VPC names", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('Production VPC')).toBeInTheDocument();
-    expect(screen.getByText('Development VPC')).toBeInTheDocument();
+    expect(screen.getByText("Production VPC")).toBeInTheDocument();
+    expect(screen.getByText("Development VPC")).toBeInTheDocument();
   });
 
-  it('renders VPC IDs', () => {
+  it("renders VPC IDs", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
-    expect(screen.getByText('vpc-456')).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
+    expect(screen.getByText("vpc-456")).toBeInTheDocument();
   });
 
-  it('renders CIDR blocks', () => {
+  it("renders CIDR blocks", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('10.0.0.0/16')).toBeInTheDocument();
-    expect(screen.getByText('172.16.0.0/16')).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/16")).toBeInTheDocument();
+    expect(screen.getByText("172.16.0.0/16")).toBeInTheDocument();
   });
 
-  it('renders default VPC indicator', () => {
+  it("renders default VPC indicator", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+    expect(screen.getByText("No")).toBeInTheDocument();
   });
 
-  it('renders DNS settings', () => {
+  it("renders DNS settings", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('✓ DNS Support')).toBeInTheDocument();
-    expect(screen.getByText('✓ DNS Hostnames')).toBeInTheDocument();
+    expect(screen.getByText("✓ DNS Support")).toBeInTheDocument();
+    expect(screen.getByText("✓ DNS Hostnames")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<VPCList {...defaultProps} />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('CIDR Block')).toBeInTheDocument();
-    expect(screen.getByText('Default')).toBeInTheDocument();
-    expect(screen.getByText('DNS')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("CIDR Block")).toBeInTheDocument();
+    expect(screen.getByText("Default")).toBeInTheDocument();
+    expect(screen.getByText("DNS")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<VPCList {...defaultProps} />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('Error loading VPCs')).toBeInTheDocument();
+    expect(screen.getByText("Error loading VPCs")).toBeInTheDocument();
   });
 
-  it('shows empty state when no VPCs', () => {
+  it("shows empty state when no VPCs", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByText('No VPCs found')).toBeInTheDocument();
+    expect(screen.getByText("No VPCs found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<VPCList {...defaultProps} />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vpc/VPCTabNavigation.test.tsx
+++ b/frontend/src/components/vpc/VPCTabNavigation.test.tsx
@@ -1,114 +1,103 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { VPCTabNavigation } from './VPCTabNavigation';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { VPCTabNavigation } from "./VPCTabNavigation";
 
-describe('VPCTabNavigation', () => {
+describe("VPCTabNavigation", () => {
   const mockOnTabChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders all tabs', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("renders all tabs", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    expect(screen.getByText('VPCs')).toBeInTheDocument();
-    expect(screen.getByText('Subnets')).toBeInTheDocument();
-    expect(screen.getByText('Internet Gateways')).toBeInTheDocument();
-    expect(screen.getByText('NAT Gateways')).toBeInTheDocument();
-    expect(screen.getByText('Elastic IPs')).toBeInTheDocument();
+    expect(screen.getByText("VPCs")).toBeInTheDocument();
+    expect(screen.getByText("Subnets")).toBeInTheDocument();
+    expect(screen.getByText("Internet Gateways")).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateways")).toBeInTheDocument();
+    expect(screen.getByText("Elastic IPs")).toBeInTheDocument();
   });
 
-  it('renders navigation element', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("renders navigation element", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
   });
 
-  it('renders all tabs as buttons', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("renders all tabs as buttons", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    const buttons = screen.getAllByRole('button');
+    const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(5);
   });
 
-  it('calls onTabChange when tab is clicked', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("calls onTabChange when tab is clicked", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    fireEvent.click(screen.getByText('Subnets'));
-    expect(mockOnTabChange).toHaveBeenCalledWith('subnets');
+    fireEvent.click(screen.getByText("Subnets"));
+    expect(mockOnTabChange).toHaveBeenCalledWith("subnets");
   });
 
-  it('calls onTabChange with correct tab key for each tab', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("calls onTabChange with correct tab key for each tab", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    fireEvent.click(screen.getByText('VPCs'));
-    expect(mockOnTabChange).toHaveBeenCalledWith('vpcs');
+    fireEvent.click(screen.getByText("VPCs"));
+    expect(mockOnTabChange).toHaveBeenCalledWith("vpcs");
 
-    fireEvent.click(screen.getByText('Internet Gateways'));
-    expect(mockOnTabChange).toHaveBeenCalledWith('internet-gateways');
+    fireEvent.click(screen.getByText("Internet Gateways"));
+    expect(mockOnTabChange).toHaveBeenCalledWith("internet-gateways");
 
-    fireEvent.click(screen.getByText('NAT Gateways'));
-    expect(mockOnTabChange).toHaveBeenCalledWith('nat-gateways');
+    fireEvent.click(screen.getByText("NAT Gateways"));
+    expect(mockOnTabChange).toHaveBeenCalledWith("nat-gateways");
 
-    fireEvent.click(screen.getByText('Elastic IPs'));
-    expect(mockOnTabChange).toHaveBeenCalledWith('elastic-ips');
+    fireEvent.click(screen.getByText("Elastic IPs"));
+    expect(mockOnTabChange).toHaveBeenCalledWith("elastic-ips");
   });
 
-  it('applies active styling to active tab', () => {
+  it("applies active styling to active tab", () => {
     render(
-      <VPCTabNavigation activeTab="subnets" onTabChange={mockOnTabChange} />
+      <VPCTabNavigation activeTab="subnets" onTabChange={mockOnTabChange} />,
     );
 
-    const subnetsTab = screen.getByText('Subnets').closest('button');
-    expect(subnetsTab).toHaveClass('border-blue-500');
-    expect(subnetsTab).toHaveClass('text-blue-600');
+    const subnetsTab = screen.getByText("Subnets").closest("button");
+    expect(subnetsTab).toHaveClass("border-blue-500");
+    expect(subnetsTab).toHaveClass("text-blue-600");
   });
 
-  it('applies inactive styling to inactive tabs', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("applies inactive styling to inactive tabs", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    const subnetsTab = screen.getByText('Subnets').closest('button');
-    expect(subnetsTab).toHaveClass('border-transparent');
-    expect(subnetsTab).toHaveClass('text-gray-500');
+    const subnetsTab = screen.getByText("Subnets").closest("button");
+    expect(subnetsTab).toHaveClass("border-transparent");
+    expect(subnetsTab).toHaveClass("text-gray-500");
   });
 
-  it('renders icons for each tab', () => {
+  it("renders icons for each tab", () => {
     const { container } = render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
+      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />,
     );
 
-    const svgs = container.querySelectorAll('svg');
+    const svgs = container.querySelectorAll("svg");
     expect(svgs).toHaveLength(5);
   });
 
-  it('shows VPCs tab as active when activeTab is vpcs', () => {
-    render(
-      <VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />
-    );
+  it("shows VPCs tab as active when activeTab is vpcs", () => {
+    render(<VPCTabNavigation activeTab="vpcs" onTabChange={mockOnTabChange} />);
 
-    const vpcsTab = screen.getByText('VPCs').closest('button');
-    expect(vpcsTab).toHaveClass('border-blue-500');
+    const vpcsTab = screen.getByText("VPCs").closest("button");
+    expect(vpcsTab).toHaveClass("border-blue-500");
   });
 
-  it('shows Elastic IPs tab as active when activeTab is elastic-ips', () => {
+  it("shows Elastic IPs tab as active when activeTab is elastic-ips", () => {
     render(
-      <VPCTabNavigation activeTab="elastic-ips" onTabChange={mockOnTabChange} />
+      <VPCTabNavigation
+        activeTab="elastic-ips"
+        onTabChange={mockOnTabChange}
+      />,
     );
 
-    const elasticIpsTab = screen.getByText('Elastic IPs').closest('button');
-    expect(elasticIpsTab).toHaveClass('border-blue-500');
+    const elasticIpsTab = screen.getByText("Elastic IPs").closest("button");
+    expect(elasticIpsTab).toHaveClass("border-blue-500");
   });
 });

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -1,20 +1,20 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { renderHook, act } from '@testing-library/react';
-import { ThemeProvider, useTheme } from './ThemeContext';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "./ThemeContext";
 
 // Get the mocked localStorage from the global setup
 const mockGetItem = vi.mocked(window.localStorage.getItem);
 const mockSetItem = vi.mocked(window.localStorage.setItem);
 
-describe('ThemeProvider', () => {
+describe("ThemeProvider", () => {
   beforeEach(() => {
     // Reset mocks
     vi.clearAllMocks();
     // Default: no stored theme
     mockGetItem.mockReturnValue(null);
     // Reset document class
-    document.documentElement.classList.remove('dark');
+    document.documentElement.classList.remove("dark");
     // Reset matchMedia mock to return false (light mode preference)
     vi.mocked(window.matchMedia).mockImplementation((query) => ({
       matches: false,
@@ -28,18 +28,18 @@ describe('ThemeProvider', () => {
     }));
   });
 
-  it('renders children', () => {
+  it("renders children", () => {
     render(
       <ThemeProvider>
         <div data-testid="child">Child content</div>
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('child')).toBeInTheDocument();
-    expect(screen.getByText('Child content')).toBeInTheDocument();
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
   });
 
-  it('defaults to light theme when no preference set', () => {
+  it("defaults to light theme when no preference set", () => {
     function TestComponent() {
       const { theme } = useTheme();
       return <div data-testid="theme">{theme}</div>;
@@ -48,15 +48,15 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
   });
 
-  it('respects dark mode system preference', () => {
+  it("respects dark mode system preference", () => {
     vi.mocked(window.matchMedia).mockImplementation((query) => ({
-      matches: query === '(prefers-color-scheme: dark)',
+      matches: query === "(prefers-color-scheme: dark)",
       media: query,
       onchange: null,
       addListener: vi.fn(),
@@ -74,17 +74,17 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
   });
 
-  it('respects localStorage light preference over dark system preference', () => {
-    mockGetItem.mockReturnValue('light');
+  it("respects localStorage light preference over dark system preference", () => {
+    mockGetItem.mockReturnValue("light");
 
     vi.mocked(window.matchMedia).mockImplementation((query) => ({
-      matches: query === '(prefers-color-scheme: dark)',
+      matches: query === "(prefers-color-scheme: dark)",
       media: query,
       onchange: null,
       addListener: vi.fn(),
@@ -102,14 +102,14 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
   });
 
-  it('loads dark theme from localStorage', () => {
-    mockGetItem.mockReturnValue('dark');
+  it("loads dark theme from localStorage", () => {
+    mockGetItem.mockReturnValue("dark");
 
     function TestComponent() {
       const { theme } = useTheme();
@@ -119,13 +119,13 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
   });
 
-  it('toggles theme from light to dark', () => {
+  it("toggles theme from light to dark", () => {
     function TestComponent() {
       const { theme, toggleTheme } = useTheme();
       return (
@@ -139,18 +139,18 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
 
-    fireEvent.click(screen.getByText('Toggle'));
+    fireEvent.click(screen.getByText("Toggle"));
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
   });
 
-  it('toggles theme from dark to light', () => {
-    mockGetItem.mockReturnValue('dark');
+  it("toggles theme from dark to light", () => {
+    mockGetItem.mockReturnValue("dark");
 
     function TestComponent() {
       const { theme, toggleTheme } = useTheme();
@@ -165,17 +165,17 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
 
-    fireEvent.click(screen.getByText('Toggle'));
+    fireEvent.click(screen.getByText("Toggle"));
 
-    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
   });
 
-  it('persists theme to localStorage on toggle', () => {
+  it("persists theme to localStorage on toggle", () => {
     function TestComponent() {
       const { toggleTheme } = useTheme();
       return <button onClick={toggleTheme}>Toggle</button>;
@@ -184,90 +184,90 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <TestComponent />
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
     // Initial render sets light theme
-    expect(mockSetItem).toHaveBeenCalledWith('aws-visualizer-theme', 'light');
+    expect(mockSetItem).toHaveBeenCalledWith("aws-visualizer-theme", "light");
 
-    fireEvent.click(screen.getByText('Toggle'));
+    fireEvent.click(screen.getByText("Toggle"));
 
-    expect(mockSetItem).toHaveBeenCalledWith('aws-visualizer-theme', 'dark');
+    expect(mockSetItem).toHaveBeenCalledWith("aws-visualizer-theme", "dark");
   });
 
-  it('adds dark class to document when dark theme', () => {
-    mockGetItem.mockReturnValue('dark');
+  it("adds dark class to document when dark theme", () => {
+    mockGetItem.mockReturnValue("dark");
 
     render(
       <ThemeProvider>
         <div>Test</div>
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it('removes dark class from document when light theme', () => {
-    document.documentElement.classList.add('dark');
-    mockGetItem.mockReturnValue('light');
+  it("removes dark class from document when light theme", () => {
+    document.documentElement.classList.add("dark");
+    mockGetItem.mockReturnValue("light");
 
     render(
       <ThemeProvider>
         <div>Test</div>
-      </ThemeProvider>
+      </ThemeProvider>,
     );
 
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });
 
-describe('useTheme', () => {
+describe("useTheme", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetItem.mockReturnValue(null);
-    document.documentElement.classList.remove('dark');
+    document.documentElement.classList.remove("dark");
   });
 
-  it('throws error when used outside ThemeProvider', () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it("throws error when used outside ThemeProvider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => {
       renderHook(() => useTheme());
-    }).toThrow('useTheme must be used within a ThemeProvider');
+    }).toThrow("useTheme must be used within a ThemeProvider");
 
     consoleSpy.mockRestore();
   });
 
-  it('returns theme and toggleTheme function', () => {
+  it("returns theme and toggleTheme function", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ThemeProvider>{children}</ThemeProvider>
     );
 
     const { result } = renderHook(() => useTheme(), { wrapper });
 
-    expect(result.current.theme).toBe('light');
-    expect(typeof result.current.toggleTheme).toBe('function');
+    expect(result.current.theme).toBe("light");
+    expect(typeof result.current.toggleTheme).toBe("function");
   });
 
-  it('toggleTheme updates the theme', () => {
+  it("toggleTheme updates the theme", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <ThemeProvider>{children}</ThemeProvider>
     );
 
     const { result } = renderHook(() => useTheme(), { wrapper });
 
-    expect(result.current.theme).toBe('light');
+    expect(result.current.theme).toBe("light");
 
     act(() => {
       result.current.toggleTheme();
     });
 
-    expect(result.current.theme).toBe('dark');
+    expect(result.current.theme).toBe("dark");
 
     act(() => {
       result.current.toggleTheme();
     });
 
-    expect(result.current.theme).toBe('light');
+    expect(result.current.theme).toBe("light");
   });
 });

--- a/frontend/src/hooks/useResources.test.ts
+++ b/frontend/src/hooks/useResources.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createElement } from 'react';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
 import {
   queryKeys,
   useStatusSummary,
@@ -19,87 +19,109 @@ import {
   useTerraformStates,
   useDrift,
   useTopology,
-} from './useResources';
-import type { DisplayStatus } from '@/types';
+} from "./useResources";
+import type { DisplayStatus } from "@/types";
 
 // Mock the API module with proper response structures
-vi.mock('@/api', () => ({
+vi.mock("@/api", () => ({
   getStatusSummary: vi.fn(() =>
     Promise.resolve({
       total_resources: 10,
-      last_refreshed: '2024-01-15T12:00:00Z',
-    })
+      last_refreshed: "2024-01-15T12:00:00Z",
+    }),
   ),
   getEC2Instances: vi.fn(() =>
     Promise.resolve({
-      data: [{ instance_id: 'i-123', name: 'Test Instance' }],
+      data: [{ instance_id: "i-123", name: "Test Instance" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getEC2Instance: vi.fn((id: string) =>
-    Promise.resolve({ instance_id: id, name: 'Test Instance' })
+    Promise.resolve({ instance_id: id, name: "Test Instance" }),
   ),
   getRDSInstances: vi.fn(() =>
     Promise.resolve({
-      data: [{ db_instance_identifier: 'rds-123', name: 'Test RDS' }],
+      data: [{ db_instance_identifier: "rds-123", name: "Test RDS" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getRDSInstance: vi.fn((id: string) =>
-    Promise.resolve({ db_instance_identifier: id, name: 'Test RDS' })
+    Promise.resolve({ db_instance_identifier: id, name: "Test RDS" }),
   ),
   getVPCs: vi.fn(() =>
     Promise.resolve({
-      data: [{ vpc_id: 'vpc-123', name: 'Test VPC' }],
+      data: [{ vpc_id: "vpc-123", name: "Test VPC" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
-  getVPC: vi.fn((id: string) => Promise.resolve({ vpc_id: id, name: 'Test VPC' })),
+  getVPC: vi.fn((id: string) =>
+    Promise.resolve({ vpc_id: id, name: "Test VPC" }),
+  ),
   getSubnets: vi.fn(() =>
     Promise.resolve({
-      data: [{ subnet_id: 'subnet-123', name: 'Test Subnet' }],
+      data: [{ subnet_id: "subnet-123", name: "Test Subnet" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getSubnet: vi.fn((id: string) =>
-    Promise.resolve({ subnet_id: id, name: 'Test Subnet' })
+    Promise.resolve({ subnet_id: id, name: "Test Subnet" }),
   ),
   getInternetGateways: vi.fn(() =>
     Promise.resolve({
-      data: [{ igw_id: 'igw-123', name: 'Test IGW' }],
+      data: [{ igw_id: "igw-123", name: "Test IGW" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getInternetGateway: vi.fn((id: string) =>
-    Promise.resolve({ igw_id: id, name: 'Test IGW' })
+    Promise.resolve({ igw_id: id, name: "Test IGW" }),
   ),
   getNATGateways: vi.fn(() =>
     Promise.resolve({
-      data: [{ nat_gateway_id: 'nat-123', name: 'Test NAT' }],
+      data: [{ nat_gateway_id: "nat-123", name: "Test NAT" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getNATGateway: vi.fn((id: string) =>
-    Promise.resolve({ nat_gateway_id: id, name: 'Test NAT' })
+    Promise.resolve({ nat_gateway_id: id, name: "Test NAT" }),
   ),
   getElasticIPs: vi.fn(() =>
     Promise.resolve({
-      data: [{ allocation_id: 'eip-123', public_ip: '1.2.3.4' }],
+      data: [{ allocation_id: "eip-123", public_ip: "1.2.3.4" }],
       meta: { total: 1, last_refreshed: null },
-    })
+    }),
   ),
   getElasticIP: vi.fn((id: string) =>
-    Promise.resolve({ allocation_id: id, public_ip: '1.2.3.4' })
+    Promise.resolve({ allocation_id: id, public_ip: "1.2.3.4" }),
   ),
   refreshData: vi.fn(() => Promise.resolve({ success: true })),
   getTerraformStates: vi.fn(() =>
     Promise.resolve({
-      states: [{ name: 'state-1', resource_count: 5 }],
+      states: [{ name: "state-1", resource_count: 5 }],
       total_tf_managed_resources: 5,
-    })
+    }),
   ),
-  getDrift: vi.fn(() => Promise.resolve({ drift_detected: false, items: [], checked_at: '2024-01-15T12:00:00Z' })),
-  getTopology: vi.fn(() => Promise.resolve({ vpcs: [], meta: { total_vpcs: 0, total_subnets: 0, total_ec2: 0, total_rds: 0, total_nat_gateways: 0, total_internet_gateways: 0, total_elastic_ips: 0, last_refreshed: null } })),
+  getDrift: vi.fn(() =>
+    Promise.resolve({
+      drift_detected: false,
+      items: [],
+      checked_at: "2024-01-15T12:00:00Z",
+    }),
+  ),
+  getTopology: vi.fn(() =>
+    Promise.resolve({
+      vpcs: [],
+      meta: {
+        total_vpcs: 0,
+        total_subnets: 0,
+        total_ec2: 0,
+        total_rds: 0,
+        total_nat_gateways: 0,
+        total_internet_gateways: 0,
+        total_elastic_ips: 0,
+        last_refreshed: null,
+      },
+    }),
+  ),
 }));
 
 function createWrapper() {
@@ -111,53 +133,57 @@ function createWrapper() {
     },
   });
   return function Wrapper({ children }: { children: React.ReactNode }) {
-    return createElement(QueryClientProvider, { client: queryClient }, children);
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
   };
 }
 
-describe('queryKeys', () => {
-  it('generates correct status summary key', () => {
-    expect(queryKeys.statusSummary).toEqual(['status-summary']);
+describe("queryKeys", () => {
+  it("generates correct status summary key", () => {
+    expect(queryKeys.statusSummary).toEqual(["status-summary"]);
   });
 
-  it('generates correct ec2 instances key with filters', () => {
-    const filters = { search: 'test' };
-    expect(queryKeys.ec2Instances(filters)).toEqual(['ec2-instances', filters]);
+  it("generates correct ec2 instances key with filters", () => {
+    const filters = { search: "test" };
+    expect(queryKeys.ec2Instances(filters)).toEqual(["ec2-instances", filters]);
   });
 
-  it('generates correct ec2 instance key', () => {
-    expect(queryKeys.ec2Instance('i-123')).toEqual(['ec2-instance', 'i-123']);
+  it("generates correct ec2 instance key", () => {
+    expect(queryKeys.ec2Instance("i-123")).toEqual(["ec2-instance", "i-123"]);
   });
 
-  it('generates correct rds instances key with filters', () => {
-    const filters = { status: 'active' as DisplayStatus };
-    expect(queryKeys.rdsInstances(filters)).toEqual(['rds-instances', filters]);
+  it("generates correct rds instances key with filters", () => {
+    const filters = { status: "active" as DisplayStatus };
+    expect(queryKeys.rdsInstances(filters)).toEqual(["rds-instances", filters]);
   });
 
-  it('generates correct vpc key', () => {
-    expect(queryKeys.vpc('vpc-123')).toEqual(['vpc', 'vpc-123']);
+  it("generates correct vpc key", () => {
+    expect(queryKeys.vpc("vpc-123")).toEqual(["vpc", "vpc-123"]);
   });
 
-  it('generates correct subnet key', () => {
-    expect(queryKeys.subnet('subnet-123')).toEqual(['subnet', 'subnet-123']);
+  it("generates correct subnet key", () => {
+    expect(queryKeys.subnet("subnet-123")).toEqual(["subnet", "subnet-123"]);
   });
 
-  it('generates correct terraform states key', () => {
-    expect(queryKeys.terraformStates).toEqual(['terraform-states']);
+  it("generates correct terraform states key", () => {
+    expect(queryKeys.terraformStates).toEqual(["terraform-states"]);
   });
 
-  it('generates correct topology key with filters', () => {
-    const filters = { vpc_id: 'vpc-123' };
-    expect(queryKeys.topology(filters)).toEqual(['topology', filters]);
+  it("generates correct topology key with filters", () => {
+    const filters = { vpc_id: "vpc-123" };
+    expect(queryKeys.topology(filters)).toEqual(["topology", filters]);
   });
 });
 
-describe('useStatusSummary', () => {
+describe("useStatusSummary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches status summary data', async () => {
+  it("fetches status summary data", async () => {
     const { result } = renderHook(() => useStatusSummary(), {
       wrapper: createWrapper(),
     });
@@ -166,17 +192,17 @@ describe('useStatusSummary', () => {
 
     expect(result.current.data).toEqual({
       total_resources: 10,
-      last_refreshed: '2024-01-15T12:00:00Z',
+      last_refreshed: "2024-01-15T12:00:00Z",
     });
   });
 });
 
-describe('useEC2Instances', () => {
+describe("useEC2Instances", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches EC2 instances', async () => {
+  it("fetches EC2 instances", async () => {
     const { result } = renderHook(() => useEC2Instances(), {
       wrapper: createWrapper(),
     });
@@ -184,11 +210,11 @@ describe('useEC2Instances', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data?.[0].instance_id).toBe('i-123');
+    expect(result.current.data?.data?.[0].instance_id).toBe("i-123");
   });
 
-  it('fetches EC2 instances with filters', async () => {
-    const filters = { search: 'test' };
+  it("fetches EC2 instances with filters", async () => {
+    const filters = { search: "test" };
     const { result } = renderHook(() => useEC2Instances(filters), {
       wrapper: createWrapper(),
     });
@@ -197,36 +223,36 @@ describe('useEC2Instances', () => {
   });
 });
 
-describe('useEC2Instance', () => {
+describe("useEC2Instance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches single EC2 instance', async () => {
-    const { result } = renderHook(() => useEC2Instance('i-123'), {
+  it("fetches single EC2 instance", async () => {
+    const { result } = renderHook(() => useEC2Instance("i-123"), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.instance_id).toBe('i-123');
+    expect(result.current.data?.instance_id).toBe("i-123");
   });
 
-  it('does not fetch when instanceId is empty', () => {
-    const { result } = renderHook(() => useEC2Instance(''), {
+  it("does not fetch when instanceId is empty", () => {
+    const { result } = renderHook(() => useEC2Instance(""), {
       wrapper: createWrapper(),
     });
 
-    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.fetchStatus).toBe("idle");
   });
 });
 
-describe('useRDSInstances', () => {
+describe("useRDSInstances", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches RDS instances', async () => {
+  it("fetches RDS instances", async () => {
     const { result } = renderHook(() => useRDSInstances(), {
       wrapper: createWrapper(),
     });
@@ -237,28 +263,28 @@ describe('useRDSInstances', () => {
   });
 });
 
-describe('useRDSInstance', () => {
+describe("useRDSInstance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches single RDS instance', async () => {
-    const { result } = renderHook(() => useRDSInstance('rds-123'), {
+  it("fetches single RDS instance", async () => {
+    const { result } = renderHook(() => useRDSInstance("rds-123"), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.db_instance_identifier).toBe('rds-123');
+    expect(result.current.data?.db_instance_identifier).toBe("rds-123");
   });
 });
 
-describe('useVPCs', () => {
+describe("useVPCs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches VPCs', async () => {
+  it("fetches VPCs", async () => {
     const { result } = renderHook(() => useVPCs(), {
       wrapper: createWrapper(),
     });
@@ -266,32 +292,32 @@ describe('useVPCs', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data?.[0].vpc_id).toBe('vpc-123');
+    expect(result.current.data?.data?.[0].vpc_id).toBe("vpc-123");
   });
 });
 
-describe('useVPC', () => {
+describe("useVPC", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches single VPC', async () => {
-    const { result } = renderHook(() => useVPC('vpc-123'), {
+  it("fetches single VPC", async () => {
+    const { result } = renderHook(() => useVPC("vpc-123"), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.vpc_id).toBe('vpc-123');
+    expect(result.current.data?.vpc_id).toBe("vpc-123");
   });
 });
 
-describe('useSubnets', () => {
+describe("useSubnets", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches subnets', async () => {
+  it("fetches subnets", async () => {
     const { result } = renderHook(() => useSubnets(), {
       wrapper: createWrapper(),
     });
@@ -302,28 +328,28 @@ describe('useSubnets', () => {
   });
 });
 
-describe('useSubnet', () => {
+describe("useSubnet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches single subnet', async () => {
-    const { result } = renderHook(() => useSubnet('subnet-123'), {
+  it("fetches single subnet", async () => {
+    const { result } = renderHook(() => useSubnet("subnet-123"), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.subnet_id).toBe('subnet-123');
+    expect(result.current.data?.subnet_id).toBe("subnet-123");
   });
 });
 
-describe('useInternetGateways', () => {
+describe("useInternetGateways", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches internet gateways', async () => {
+  it("fetches internet gateways", async () => {
     const { result } = renderHook(() => useInternetGateways(), {
       wrapper: createWrapper(),
     });
@@ -334,12 +360,12 @@ describe('useInternetGateways', () => {
   });
 });
 
-describe('useNATGateways', () => {
+describe("useNATGateways", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches NAT gateways', async () => {
+  it("fetches NAT gateways", async () => {
     const { result } = renderHook(() => useNATGateways(), {
       wrapper: createWrapper(),
     });
@@ -350,12 +376,12 @@ describe('useNATGateways', () => {
   });
 });
 
-describe('useElasticIPs', () => {
+describe("useElasticIPs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches elastic IPs', async () => {
+  it("fetches elastic IPs", async () => {
     const { result } = renderHook(() => useElasticIPs(), {
       wrapper: createWrapper(),
     });
@@ -363,16 +389,16 @@ describe('useElasticIPs', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data?.[0].public_ip).toBe('1.2.3.4');
+    expect(result.current.data?.data?.[0].public_ip).toBe("1.2.3.4");
   });
 });
 
-describe('useTerraformStates', () => {
+describe("useTerraformStates", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches terraform states', async () => {
+  it("fetches terraform states", async () => {
     const { result } = renderHook(() => useTerraformStates(), {
       wrapper: createWrapper(),
     });
@@ -380,16 +406,16 @@ describe('useTerraformStates', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.states).toHaveLength(1);
-    expect(result.current.data?.states?.[0].name).toBe('state-1');
+    expect(result.current.data?.states?.[0].name).toBe("state-1");
   });
 });
 
-describe('useDrift', () => {
+describe("useDrift", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches drift data', async () => {
+  it("fetches drift data", async () => {
     const { result } = renderHook(() => useDrift(), {
       wrapper: createWrapper(),
     });
@@ -400,12 +426,12 @@ describe('useDrift', () => {
   });
 });
 
-describe('useTopology', () => {
+describe("useTopology", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('fetches topology data', async () => {
+  it("fetches topology data", async () => {
     const { result } = renderHook(() => useTopology(), {
       wrapper: createWrapper(),
     });
@@ -415,8 +441,8 @@ describe('useTopology', () => {
     expect(result.current.data?.vpcs).toEqual([]);
   });
 
-  it('fetches topology with VPC filter', async () => {
-    const { result } = renderHook(() => useTopology({ vpc_id: 'vpc-123' }), {
+  it("fetches topology with VPC filter", async () => {
+    const { result } = renderHook(() => useTopology({ vpc_id: "vpc-123" }), {
       wrapper: createWrapper(),
     });
 

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   cn,
   formatRelativeTime,
@@ -8,44 +8,44 @@ import {
   getResourceName,
   truncateId,
   buildQueryString,
-} from './utils';
+} from "./utils";
 
-describe('cn (className utility)', () => {
-  it('merges class names', () => {
-    expect(cn('foo', 'bar')).toBe('foo bar');
+describe("cn (className utility)", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
   });
 
-  it('handles conditional classes', () => {
+  it("handles conditional classes", () => {
     const includeBar = true;
     const includeBaz = false;
-    expect(cn('foo', includeBar && 'bar', includeBaz && 'baz')).toBe('foo bar');
+    expect(cn("foo", includeBar && "bar", includeBaz && "baz")).toBe("foo bar");
   });
 
-  it('merges tailwind classes correctly', () => {
-    expect(cn('px-2 py-1', 'px-4')).toBe('py-1 px-4');
+  it("merges tailwind classes correctly", () => {
+    expect(cn("px-2 py-1", "px-4")).toBe("py-1 px-4");
   });
 
-  it('handles arrays', () => {
-    expect(cn(['foo', 'bar'])).toBe('foo bar');
+  it("handles arrays", () => {
+    expect(cn(["foo", "bar"])).toBe("foo bar");
   });
 
-  it('handles objects', () => {
-    expect(cn({ foo: true, bar: false, baz: true })).toBe('foo baz');
+  it("handles objects", () => {
+    expect(cn({ foo: true, bar: false, baz: true })).toBe("foo baz");
   });
 
-  it('handles empty inputs', () => {
-    expect(cn()).toBe('');
+  it("handles empty inputs", () => {
+    expect(cn()).toBe("");
   });
 
-  it('handles undefined and null', () => {
-    expect(cn('foo', undefined, null, 'bar')).toBe('foo bar');
+  it("handles undefined and null", () => {
+    expect(cn("foo", undefined, null, "bar")).toBe("foo bar");
   });
 });
 
-describe('formatRelativeTime', () => {
+describe("formatRelativeTime", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+    vi.setSystemTime(new Date("2024-01-15T12:00:00Z"));
   });
 
   afterEach(() => {
@@ -53,184 +53,184 @@ describe('formatRelativeTime', () => {
   });
 
   it('returns "Never" for null', () => {
-    expect(formatRelativeTime(null)).toBe('Never');
+    expect(formatRelativeTime(null)).toBe("Never");
   });
 
   it('returns "Never" for undefined', () => {
-    expect(formatRelativeTime(undefined)).toBe('Never');
+    expect(formatRelativeTime(undefined)).toBe("Never");
   });
 
-  it('formats recent date correctly', () => {
-    const result = formatRelativeTime('2024-01-15T11:55:00Z');
-    expect(result).toContain('minutes ago');
+  it("formats recent date correctly", () => {
+    const result = formatRelativeTime("2024-01-15T11:55:00Z");
+    expect(result).toContain("minutes ago");
   });
 
-  it('formats date from yesterday', () => {
-    const result = formatRelativeTime('2024-01-14T12:00:00Z');
-    expect(result).toContain('day ago');
+  it("formats date from yesterday", () => {
+    const result = formatRelativeTime("2024-01-14T12:00:00Z");
+    expect(result).toContain("day ago");
   });
 
-  it('formats date from a week ago', () => {
-    const result = formatRelativeTime('2024-01-08T12:00:00Z');
-    expect(result).toContain('7 days ago');
+  it("formats date from a week ago", () => {
+    const result = formatRelativeTime("2024-01-08T12:00:00Z");
+    expect(result).toContain("7 days ago");
   });
 
   it('returns "Unknown" for invalid date string', () => {
-    expect(formatRelativeTime('not-a-date')).toBe('Unknown');
+    expect(formatRelativeTime("not-a-date")).toBe("Unknown");
   });
 });
 
-describe('formatDateTime', () => {
+describe("formatDateTime", () => {
   it('returns "N/A" for null', () => {
-    expect(formatDateTime(null)).toBe('N/A');
+    expect(formatDateTime(null)).toBe("N/A");
   });
 
   it('returns "N/A" for undefined', () => {
-    expect(formatDateTime(undefined)).toBe('N/A');
+    expect(formatDateTime(undefined)).toBe("N/A");
   });
 
-  it('formats date correctly', () => {
-    const result = formatDateTime('2024-01-15T14:30:45Z');
+  it("formats date correctly", () => {
+    const result = formatDateTime("2024-01-15T14:30:45Z");
     expect(result).toMatch(/Jan 15, 2024/);
   });
 
   it('returns "Invalid date" for invalid date string', () => {
-    expect(formatDateTime('not-a-date')).toBe('Invalid date');
+    expect(formatDateTime("not-a-date")).toBe("Invalid date");
   });
 });
 
-describe('statusConfig', () => {
-  it('has all required status types', () => {
-    expect(statusConfig).toHaveProperty('active');
-    expect(statusConfig).toHaveProperty('inactive');
-    expect(statusConfig).toHaveProperty('transitioning');
-    expect(statusConfig).toHaveProperty('error');
-    expect(statusConfig).toHaveProperty('unknown');
+describe("statusConfig", () => {
+  it("has all required status types", () => {
+    expect(statusConfig).toHaveProperty("active");
+    expect(statusConfig).toHaveProperty("inactive");
+    expect(statusConfig).toHaveProperty("transitioning");
+    expect(statusConfig).toHaveProperty("error");
+    expect(statusConfig).toHaveProperty("unknown");
   });
 
-  it('each status has required properties', () => {
+  it("each status has required properties", () => {
     Object.values(statusConfig).forEach((config) => {
-      expect(config).toHaveProperty('label');
-      expect(config).toHaveProperty('color');
-      expect(config).toHaveProperty('bgColor');
-      expect(config).toHaveProperty('dotColor');
+      expect(config).toHaveProperty("label");
+      expect(config).toHaveProperty("color");
+      expect(config).toHaveProperty("bgColor");
+      expect(config).toHaveProperty("dotColor");
     });
   });
 });
 
-describe('getStatusConfig', () => {
-  it('returns config for active status', () => {
-    const config = getStatusConfig('active');
-    expect(config.label).toBe('Active');
-    expect(config.dotColor).toBe('bg-green-500');
+describe("getStatusConfig", () => {
+  it("returns config for active status", () => {
+    const config = getStatusConfig("active");
+    expect(config.label).toBe("Active");
+    expect(config.dotColor).toBe("bg-green-500");
   });
 
-  it('returns config for inactive status', () => {
-    const config = getStatusConfig('inactive');
-    expect(config.label).toBe('Inactive');
+  it("returns config for inactive status", () => {
+    const config = getStatusConfig("inactive");
+    expect(config.label).toBe("Inactive");
   });
 
-  it('returns config for transitioning status', () => {
-    const config = getStatusConfig('transitioning');
-    expect(config.label).toBe('Transit');
+  it("returns config for transitioning status", () => {
+    const config = getStatusConfig("transitioning");
+    expect(config.label).toBe("Transit");
   });
 
-  it('returns config for error status', () => {
-    const config = getStatusConfig('error');
-    expect(config.label).toBe('Error');
+  it("returns config for error status", () => {
+    const config = getStatusConfig("error");
+    expect(config.label).toBe("Error");
   });
 
-  it('returns config for unknown status', () => {
-    const config = getStatusConfig('unknown');
-    expect(config.label).toBe('Unknown');
+  it("returns config for unknown status", () => {
+    const config = getStatusConfig("unknown");
+    expect(config.label).toBe("Unknown");
   });
 
-  it('returns unknown config for invalid status', () => {
+  it("returns unknown config for invalid status", () => {
     // @ts-expect-error Testing invalid status
-    const config = getStatusConfig('invalid');
-    expect(config.label).toBe('Unknown');
+    const config = getStatusConfig("invalid");
+    expect(config.label).toBe("Unknown");
   });
 });
 
-describe('getResourceName', () => {
-  it('returns name when provided', () => {
-    expect(getResourceName('MyResource', 'res-123')).toBe('MyResource');
+describe("getResourceName", () => {
+  it("returns name when provided", () => {
+    expect(getResourceName("MyResource", "res-123")).toBe("MyResource");
   });
 
-  it('returns id when name is null', () => {
-    expect(getResourceName(null, 'res-123')).toBe('res-123');
+  it("returns id when name is null", () => {
+    expect(getResourceName(null, "res-123")).toBe("res-123");
   });
 
-  it('returns id when name is undefined', () => {
-    expect(getResourceName(undefined, 'res-123')).toBe('res-123');
+  it("returns id when name is undefined", () => {
+    expect(getResourceName(undefined, "res-123")).toBe("res-123");
   });
 
-  it('returns id when name is empty string', () => {
-    expect(getResourceName('', 'res-123')).toBe('res-123');
+  it("returns id when name is empty string", () => {
+    expect(getResourceName("", "res-123")).toBe("res-123");
   });
 });
 
-describe('truncateId', () => {
-  it('returns original id if shorter than maxLength', () => {
-    expect(truncateId('short-id', 20)).toBe('short-id');
+describe("truncateId", () => {
+  it("returns original id if shorter than maxLength", () => {
+    expect(truncateId("short-id", 20)).toBe("short-id");
   });
 
-  it('returns original id if equal to maxLength', () => {
-    expect(truncateId('exactly-20-chars-id!', 20)).toBe('exactly-20-chars-id!');
+  it("returns original id if equal to maxLength", () => {
+    expect(truncateId("exactly-20-chars-id!", 20)).toBe("exactly-20-chars-id!");
   });
 
-  it('truncates long id with ellipsis', () => {
-    const result = truncateId('this-is-a-very-long-resource-id', 20);
-    expect(result).toBe('this-is-a-very-lo...');
+  it("truncates long id with ellipsis", () => {
+    const result = truncateId("this-is-a-very-long-resource-id", 20);
+    expect(result).toBe("this-is-a-very-lo...");
     expect(result.length).toBe(20);
   });
 
-  it('uses default maxLength of 20', () => {
-    const result = truncateId('this-is-a-very-long-resource-identifier');
+  it("uses default maxLength of 20", () => {
+    const result = truncateId("this-is-a-very-long-resource-identifier");
     expect(result.length).toBe(20);
-    expect(result.endsWith('...')).toBe(true);
+    expect(result.endsWith("...")).toBe(true);
   });
 
-  it('handles custom maxLength', () => {
-    const result = truncateId('1234567890', 8);
-    expect(result).toBe('12345...');
+  it("handles custom maxLength", () => {
+    const result = truncateId("1234567890", 8);
+    expect(result).toBe("12345...");
     expect(result.length).toBe(8);
   });
 });
 
-describe('buildQueryString', () => {
-  it('builds query string from params', () => {
-    const result = buildQueryString({ foo: 'bar', baz: 'qux' });
-    expect(result).toBe('foo=bar&baz=qux');
+describe("buildQueryString", () => {
+  it("builds query string from params", () => {
+    const result = buildQueryString({ foo: "bar", baz: "qux" });
+    expect(result).toBe("foo=bar&baz=qux");
   });
 
-  it('handles boolean values', () => {
+  it("handles boolean values", () => {
     const result = buildQueryString({ active: true, disabled: false });
-    expect(result).toBe('active=true&disabled=false');
+    expect(result).toBe("active=true&disabled=false");
   });
 
-  it('excludes undefined values', () => {
-    const result = buildQueryString({ foo: 'bar', baz: undefined });
-    expect(result).toBe('foo=bar');
+  it("excludes undefined values", () => {
+    const result = buildQueryString({ foo: "bar", baz: undefined });
+    expect(result).toBe("foo=bar");
   });
 
-  it('excludes empty string values', () => {
-    const result = buildQueryString({ foo: 'bar', baz: '' });
-    expect(result).toBe('foo=bar');
+  it("excludes empty string values", () => {
+    const result = buildQueryString({ foo: "bar", baz: "" });
+    expect(result).toBe("foo=bar");
   });
 
-  it('returns empty string for no valid params', () => {
-    const result = buildQueryString({ foo: undefined, bar: '' });
-    expect(result).toBe('');
+  it("returns empty string for no valid params", () => {
+    const result = buildQueryString({ foo: undefined, bar: "" });
+    expect(result).toBe("");
   });
 
-  it('returns empty string for empty object', () => {
+  it("returns empty string for empty object", () => {
     const result = buildQueryString({});
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('encodes special characters', () => {
-    const result = buildQueryString({ search: 'hello world' });
-    expect(result).toBe('search=hello+world');
+  it("encodes special characters", () => {
+    const result = buildQueryString({ search: "hello world" });
+    expect(result).toBe("search=hello+world");
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -58,10 +58,10 @@ export const statusConfig: Record<
     dotColor: "bg-gray-400 dark:bg-gray-500",
   },
   transitioning: {
-    label: 'Transit',
-    color: 'text-yellow-700 dark:text-yellow-300',
-    bgColor: 'bg-yellow-50 dark:bg-yellow-900/30',
-    dotColor: 'bg-yellow-500',
+    label: "Transit",
+    color: "text-yellow-700 dark:text-yellow-300",
+    bgColor: "bg-yellow-50 dark:bg-yellow-900/30",
+    dotColor: "bg-yellow-500",
   },
   error: {
     label: "Error",

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { DashboardPage } from './Dashboard';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { DashboardPage } from "./Dashboard";
 
 // Mock data
 const mockSummary = {
   ec2: { total: 5, active: 3, inactive: 1, transitioning: 1, error: 0 },
   rds: { total: 3, active: 2, inactive: 1, transitioning: 0, error: 0 },
-  last_refreshed: '2024-01-15T12:00:00Z',
+  last_refreshed: "2024-01-15T12:00:00Z",
 };
 
 const mockEC2Instances = [
   {
-    instance_id: 'i-123',
-    name: 'web-server-1',
-    instance_type: 't3.micro',
-    display_status: 'active',
+    instance_id: "i-123",
+    name: "web-server-1",
+    instance_type: "t3.micro",
+    display_status: "active",
   },
   {
-    instance_id: 'i-456',
-    name: 'api-server-1',
-    instance_type: 't3.small',
-    display_status: 'inactive',
+    instance_id: "i-456",
+    name: "api-server-1",
+    instance_type: "t3.small",
+    display_status: "inactive",
   },
 ];
 
 const mockRDSInstances = [
   {
-    db_instance_identifier: 'prod-db',
-    name: 'Production DB',
-    engine: 'mysql',
-    engine_version: '8.0',
-    display_status: 'active',
+    db_instance_identifier: "prod-db",
+    name: "Production DB",
+    engine: "mysql",
+    engine_version: "8.0",
+    display_status: "active",
   },
 ];
 
@@ -40,14 +40,19 @@ const mockDrift = {
 };
 
 const mockVPCs = [
-  { vpc_id: 'vpc-123', name: 'main-vpc', cidr_block: '10.0.0.0/16', display_status: 'active' },
+  {
+    vpc_id: "vpc-123",
+    name: "main-vpc",
+    cidr_block: "10.0.0.0/16",
+    display_status: "active",
+  },
 ];
 
 let mockSummaryLoading = false;
 let mockEc2Loading = false;
 let mockRdsLoading = false;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useStatusSummary: () => ({
     data: mockSummaryLoading ? null : mockSummary,
     isLoading: mockSummaryLoading,
@@ -81,7 +86,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('DashboardPage', () => {
+describe("DashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSummaryLoading = false;
@@ -89,86 +94,88 @@ describe('DashboardPage', () => {
     mockRdsLoading = false;
   });
 
-  it('renders page title', () => {
+  it("renders page title", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
   });
 
-  it('renders page description', () => {
+  it("renders page description", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Overview of your AWS infrastructure')).toBeInTheDocument();
+    expect(
+      screen.getByText("Overview of your AWS infrastructure"),
+    ).toBeInTheDocument();
   });
 
-  it('renders EC2 summary card', () => {
+  it("renders EC2 summary card", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('EC2 Instances')).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instances")).toBeInTheDocument();
   });
 
-  it('renders RDS summary card', () => {
+  it("renders RDS summary card", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('RDS Databases')).toBeInTheDocument();
+    expect(screen.getByText("RDS Databases")).toBeInTheDocument();
   });
 
-  it('renders Terraform Status card', () => {
+  it("renders Terraform Status card", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Terraform Status')).toBeInTheDocument();
+    expect(screen.getByText("Terraform Status")).toBeInTheDocument();
   });
 
-  it('shows no drift message when no drift detected', () => {
+  it("shows no drift message when no drift detected", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('No drift detected')).toBeInTheDocument();
+    expect(screen.getByText("No drift detected")).toBeInTheDocument();
   });
 
-  it('renders Recent EC2 Instances section', () => {
+  it("renders Recent EC2 Instances section", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Recent EC2 Instances')).toBeInTheDocument();
+    expect(screen.getByText("Recent EC2 Instances")).toBeInTheDocument();
   });
 
-  it('renders Recent RDS Databases section', () => {
+  it("renders Recent RDS Databases section", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Recent RDS Databases')).toBeInTheDocument();
+    expect(screen.getByText("Recent RDS Databases")).toBeInTheDocument();
   });
 
-  it('renders EC2 instance data', () => {
+  it("renders EC2 instance data", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('web-server-1')).toBeInTheDocument();
-    expect(screen.getByText('t3.micro')).toBeInTheDocument();
+    expect(screen.getByText("web-server-1")).toBeInTheDocument();
+    expect(screen.getByText("t3.micro")).toBeInTheDocument();
   });
 
-  it('renders RDS instance data', () => {
+  it("renders RDS instance data", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Production DB')).toBeInTheDocument();
-    expect(screen.getByText('mysql 8.0')).toBeInTheDocument();
+    expect(screen.getByText("Production DB")).toBeInTheDocument();
+    expect(screen.getByText("mysql 8.0")).toBeInTheDocument();
   });
 
-  it('renders view all links', () => {
+  it("renders view all links", () => {
     render(<DashboardPage />);
-    const viewAllLinks = screen.getAllByText('View all →');
+    const viewAllLinks = screen.getAllByText("View all →");
     // Now there are 3 "View all" links (EC2, RDS, VPC)
     expect(viewAllLinks).toHaveLength(3);
   });
 
-  it('renders View Terraform details link', () => {
+  it("renders View Terraform details link", () => {
     render(<DashboardPage />);
-    expect(screen.getByText('View Terraform details →')).toBeInTheDocument();
+    expect(screen.getByText("View Terraform details →")).toBeInTheDocument();
   });
 
-  it('shows loading state when summary is loading', () => {
+  it("shows loading state when summary is loading", () => {
     mockSummaryLoading = true;
     const { container } = render(<DashboardPage />);
     // PageLoading shows a spinner with animate-spin class
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows loading message for EC2 when loading', () => {
+  it("shows loading message for EC2 when loading", () => {
     mockEc2Loading = true;
     render(<DashboardPage />);
     // The loading message is inside the EC2 card
-    const loadingElements = screen.getAllByText('Loading...');
+    const loadingElements = screen.getAllByText("Loading...");
     expect(loadingElements.length).toBeGreaterThan(0);
   });
 
-  it('renders last refresh time', () => {
+  it("renders last refresh time", () => {
     render(<DashboardPage />);
     expect(screen.getByText(/Data last refreshed/)).toBeInTheDocument();
   });

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,21 +1,49 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { Server, Database, GitBranch, AlertTriangle, CheckCircle, Network } from 'lucide-react';
-import { Card, CardHeader, CardTitle, CardContent, PageLoading, StatusBadge, Select } from '@/components/common';
-import { ResourceSummaryCard } from '@/components/dashboard';
-import { useStatusSummary, useEC2Instances, useRDSInstances, useDrift, useVPCs, useSubnets, useInternetGateways, useNATGateways, useElasticIPs } from '@/hooks';
-import { formatRelativeTime, getResourceName } from '@/lib/utils';
-import type { EC2Instance, RDSInstance, VPC, ResourceFilters } from '@/types';
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Server,
+  Database,
+  GitBranch,
+  AlertTriangle,
+  CheckCircle,
+  Network,
+} from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  PageLoading,
+  StatusBadge,
+  Select,
+} from "@/components/common";
+import { ResourceSummaryCard } from "@/components/dashboard";
+import {
+  useStatusSummary,
+  useEC2Instances,
+  useRDSInstances,
+  useDrift,
+  useVPCs,
+  useSubnets,
+  useInternetGateways,
+  useNATGateways,
+  useElasticIPs,
+} from "@/hooks";
+import { formatRelativeTime, getResourceName } from "@/lib/utils";
+import type { EC2Instance, RDSInstance, VPC, ResourceFilters } from "@/types";
 
 const terraformOptions = [
-  { value: 'true', label: 'Managed' },
-  { value: 'false', label: 'Unmanaged' },
+  { value: "true", label: "Managed" },
+  { value: "false", label: "Unmanaged" },
 ];
 
 export function DashboardPage() {
-  const [tfManagedFilter, setTfManagedFilter] = useState<boolean | undefined>(undefined);
+  const [tfManagedFilter, setTfManagedFilter] = useState<boolean | undefined>(
+    undefined,
+  );
 
-  const filters: ResourceFilters | undefined = tfManagedFilter !== undefined ? { tf_managed: tfManagedFilter } : undefined;
+  const filters: ResourceFilters | undefined =
+    tfManagedFilter !== undefined ? { tf_managed: tfManagedFilter } : undefined;
 
   const { data: summary, isLoading: summaryLoading } = useStatusSummary();
   const { data: ec2Data, isLoading: ec2Loading } = useEC2Instances(filters);
@@ -37,18 +65,22 @@ export function DashboardPage() {
 
   // Calculate counts from filtered data
   const computeCounts = (data: { display_status: string }[] | undefined) => {
-    if (!data) return { active: 0, inactive: 0, transitioning: 0, error: 0, total: 0 };
+    if (!data)
+      return { active: 0, inactive: 0, transitioning: 0, error: 0, total: 0 };
     return {
-      active: data.filter(d => d.display_status === 'active').length,
-      inactive: data.filter(d => d.display_status === 'inactive').length,
-      transitioning: data.filter(d => d.display_status === 'transitioning').length,
-      error: data.filter(d => d.display_status === 'error').length,
+      active: data.filter((d) => d.display_status === "active").length,
+      inactive: data.filter((d) => d.display_status === "inactive").length,
+      transitioning: data.filter((d) => d.display_status === "transitioning")
+        .length,
+      error: data.filter((d) => d.display_status === "error").length,
       total: data.length,
     };
   };
 
-  const ec2Counts = tfManagedFilter !== undefined ? computeCounts(ec2Data?.data) : summary?.ec2;
-  const rdsCounts = tfManagedFilter !== undefined ? computeCounts(rdsData?.data) : summary?.rds;
+  const ec2Counts =
+    tfManagedFilter !== undefined ? computeCounts(ec2Data?.data) : summary?.ec2;
+  const rdsCounts =
+    tfManagedFilter !== undefined ? computeCounts(rdsData?.data) : summary?.rds;
 
   // Calculate VPC networking totals
   const vpcNetworkingTotal = {
@@ -63,7 +95,9 @@ export function DashboardPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Dashboard
+          </h1>
           <p className="text-gray-500 dark:text-gray-400">
             Overview of your AWS infrastructure
           </p>
@@ -72,10 +106,10 @@ export function DashboardPage() {
           <Select
             placeholder="All resources"
             options={terraformOptions}
-            value={tfManagedFilter === undefined ? '' : String(tfManagedFilter)}
+            value={tfManagedFilter === undefined ? "" : String(tfManagedFilter)}
             onChange={(e) =>
               setTfManagedFilter(
-                e.target.value === '' ? undefined : e.target.value === 'true'
+                e.target.value === "" ? undefined : e.target.value === "true",
               )
             }
           />
@@ -117,20 +151,36 @@ export function DashboardPage() {
               <CardContent>
                 <div className="grid grid-cols-2 gap-4">
                   <div className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700">
-                    <span className="text-sm text-gray-600 dark:text-gray-300">Subnets</span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">{vpcNetworkingTotal.subnets}</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      Subnets
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      {vpcNetworkingTotal.subnets}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700">
-                    <span className="text-sm text-gray-600 dark:text-gray-300">IGWs</span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">{vpcNetworkingTotal.igws}</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      IGWs
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      {vpcNetworkingTotal.igws}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700">
-                    <span className="text-sm text-gray-600 dark:text-gray-300">NAT GWs</span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">{vpcNetworkingTotal.natGateways}</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      NAT GWs
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      {vpcNetworkingTotal.natGateways}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700">
-                    <span className="text-sm text-gray-600 dark:text-gray-300">Elastic IPs</span>
-                    <span className="font-semibold text-gray-900 dark:text-gray-100">{vpcNetworkingTotal.elasticIPs}</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      Elastic IPs
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      {vpcNetworkingTotal.elasticIPs}
+                    </span>
                   </div>
                 </div>
                 <Link
@@ -280,7 +330,9 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             {vpcLoading ? (
-              <div className="py-4 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+              <div className="py-4 text-center text-gray-500 dark:text-gray-400">
+                Loading...
+              </div>
             ) : recentVPCs.length === 0 ? (
               <div className="py-4 text-center text-gray-500 dark:text-gray-400">
                 No VPCs found

--- a/frontend/src/pages/EC2List.test.tsx
+++ b/frontend/src/pages/EC2List.test.tsx
@@ -1,32 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { EC2ListPage } from './EC2List';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { EC2ListPage } from "./EC2List";
 
 // Mock the hooks
 const mockInstances = [
   {
-    instance_id: 'i-123',
-    name: 'web-server-1',
-    instance_type: 't3.micro',
-    state: 'running',
-    display_status: 'active',
-    private_ip: '10.0.1.100',
-    public_ip: '54.1.2.3',
-    availability_zone: 'us-east-1a',
+    instance_id: "i-123",
+    name: "web-server-1",
+    instance_type: "t3.micro",
+    state: "running",
+    display_status: "active",
+    private_ip: "10.0.1.100",
+    public_ip: "54.1.2.3",
+    availability_zone: "us-east-1a",
     tf_managed: true,
-    updated_at: '2024-01-15T12:00:00Z',
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    instance_id: 'i-456',
-    name: 'api-server-1',
-    instance_type: 't3.small',
-    state: 'stopped',
-    display_status: 'inactive',
-    private_ip: '10.0.1.101',
+    instance_id: "i-456",
+    name: "api-server-1",
+    instance_type: "t3.small",
+    state: "stopped",
+    display_status: "inactive",
+    private_ip: "10.0.1.101",
     public_ip: null,
-    availability_zone: 'us-east-1b',
+    availability_zone: "us-east-1b",
     tf_managed: false,
-    updated_at: '2024-01-14T12:00:00Z',
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -34,7 +34,7 @@ let mockData = { data: mockInstances, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useEC2Instances: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -42,7 +42,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('EC2ListPage', () => {
+describe("EC2ListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockData = { data: mockInstances, meta: { total: 2 } };
@@ -50,101 +50,107 @@ describe('EC2ListPage', () => {
     mockError = null;
   });
 
-  it('renders page title', () => {
+  it("renders page title", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('EC2 Instances')).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instances")).toBeInTheDocument();
   });
 
-  it('renders instance count', () => {
+  it("renders instance count", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('2 instances found')).toBeInTheDocument();
+    expect(screen.getByText("2 instances found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<EC2ListPage />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 
-  it('renders instance data in table', () => {
+  it("renders instance data in table", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('web-server-1')).toBeInTheDocument();
-    expect(screen.getByText('api-server-1')).toBeInTheDocument();
-    expect(screen.getByText('t3.micro')).toBeInTheDocument();
-    expect(screen.getByText('t3.small')).toBeInTheDocument();
+    expect(screen.getByText("web-server-1")).toBeInTheDocument();
+    expect(screen.getByText("api-server-1")).toBeInTheDocument();
+    expect(screen.getByText("t3.micro")).toBeInTheDocument();
+    expect(screen.getByText("t3.small")).toBeInTheDocument();
   });
 
-  it('renders instance IDs', () => {
+  it("renders instance IDs", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('i-123')).toBeInTheDocument();
-    expect(screen.getByText('i-456')).toBeInTheDocument();
+    expect(screen.getByText("i-123")).toBeInTheDocument();
+    expect(screen.getByText("i-456")).toBeInTheDocument();
   });
 
-  it('renders status badges', () => {
+  it("renders status badges", () => {
     render(<EC2ListPage />);
     // Multiple status badges may exist in the table and filters
-    const activeBadges = screen.getAllByText('Active');
-    const inactiveBadges = screen.getAllByText('Inactive');
+    const activeBadges = screen.getAllByText("Active");
+    const inactiveBadges = screen.getAllByText("Inactive");
     expect(activeBadges.length).toBeGreaterThan(0);
     expect(inactiveBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<EC2ListPage />);
     // Multiple terraform badges may exist
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders IP addresses', () => {
+  it("renders IP addresses", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
-    expect(screen.getByText('10.0.1.101')).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.101")).toBeInTheDocument();
   });
 
-  it('renders availability zones', () => {
+  it("renders availability zones", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('us-east-1a')).toBeInTheDocument();
-    expect(screen.getByText('us-east-1b')).toBeInTheDocument();
+    expect(screen.getByText("us-east-1a")).toBeInTheDocument();
+    expect(screen.getByText("us-east-1b")).toBeInTheDocument();
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<EC2ListPage />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Type')).toBeInTheDocument();
-    expect(screen.getByText('IP Address')).toBeInTheDocument();
-    expect(screen.getByText('AZ')).toBeInTheDocument();
-    expect(screen.getByText('Updated')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("IP Address")).toBeInTheDocument();
+    expect(screen.getByText("AZ")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<EC2ListPage />);
     // PageLoading shows a spinner with animate-spin class
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<EC2ListPage />);
-    expect(screen.getByText('Error loading EC2 instances')).toBeInTheDocument();
-    expect(screen.getByText('Failed to fetch EC2 instances. Please try again.')).toBeInTheDocument();
+    expect(screen.getByText("Error loading EC2 instances")).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to fetch EC2 instances. Please try again."),
+    ).toBeInTheDocument();
   });
 
-  it('shows empty state when no instances', () => {
+  it("shows empty state when no instances", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<EC2ListPage />);
-    expect(screen.getByText('No EC2 instances found')).toBeInTheDocument();
+    expect(screen.getByText("No EC2 instances found")).toBeInTheDocument();
   });
 
-  it('shows appropriate empty state message with filters', () => {
+  it("shows appropriate empty state message with filters", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<EC2ListPage />);
-    expect(screen.getByText('No EC2 instances are available in your account')).toBeInTheDocument();
+    expect(
+      screen.getByText("No EC2 instances are available in your account"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/EC2List.tsx
+++ b/frontend/src/pages/EC2List.tsx
@@ -133,7 +133,9 @@ export function EC2ListPage() {
           <Server className="h-6 w-6 text-orange-600 dark:text-orange-400" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">EC2 Instances</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            EC2 Instances
+          </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Amazon Elastic Compute Cloud virtual servers
           </p>

--- a/frontend/src/pages/RDSList.test.tsx
+++ b/frontend/src/pages/RDSList.test.tsx
@@ -1,31 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/test/test-utils';
-import { RDSListPage } from './RDSList';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { RDSListPage } from "./RDSList";
 
 const mockInstances = [
   {
-    db_instance_identifier: 'prod-db',
-    name: 'Production Database',
-    engine: 'mysql',
-    engine_version: '8.0',
-    db_instance_class: 'db.t3.medium',
+    db_instance_identifier: "prod-db",
+    name: "Production Database",
+    engine: "mysql",
+    engine_version: "8.0",
+    db_instance_class: "db.t3.medium",
     allocated_storage: 100,
-    display_status: 'active' as const,
+    display_status: "active" as const,
     multi_az: true,
     tf_managed: true,
-    updated_at: '2024-01-15T12:00:00Z',
+    updated_at: "2024-01-15T12:00:00Z",
   },
   {
-    db_instance_identifier: 'dev-db',
-    name: 'Development Database',
-    engine: 'postgres',
-    engine_version: '15.3',
-    db_instance_class: 'db.t3.small',
+    db_instance_identifier: "dev-db",
+    name: "Development Database",
+    engine: "postgres",
+    engine_version: "15.3",
+    db_instance_class: "db.t3.small",
     allocated_storage: 50,
-    display_status: 'active' as const,
+    display_status: "active" as const,
     multi_az: false,
     tf_managed: false,
-    updated_at: '2024-01-14T12:00:00Z',
+    updated_at: "2024-01-14T12:00:00Z",
   },
 ];
 
@@ -33,7 +33,7 @@ let mockData = { data: mockInstances, meta: { total: 2 } };
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useRDSInstances: () => ({
     data: mockData,
     isLoading: mockIsLoading,
@@ -41,7 +41,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('RDSListPage', () => {
+describe("RDSListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockData = { data: mockInstances, meta: { total: 2 } };
@@ -49,96 +49,98 @@ describe('RDSListPage', () => {
     mockError = null;
   });
 
-  it('renders page title', () => {
+  it("renders page title", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('RDS Databases')).toBeInTheDocument();
+    expect(screen.getByText("RDS Databases")).toBeInTheDocument();
   });
 
-  it('renders instance count', () => {
+  it("renders instance count", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('2 databases found')).toBeInTheDocument();
+    expect(screen.getByText("2 databases found")).toBeInTheDocument();
   });
 
-  it('renders database names', () => {
+  it("renders database names", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('Production Database')).toBeInTheDocument();
-    expect(screen.getByText('Development Database')).toBeInTheDocument();
+    expect(screen.getByText("Production Database")).toBeInTheDocument();
+    expect(screen.getByText("Development Database")).toBeInTheDocument();
   });
 
-  it('renders database identifiers', () => {
+  it("renders database identifiers", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('prod-db')).toBeInTheDocument();
-    expect(screen.getByText('dev-db')).toBeInTheDocument();
+    expect(screen.getByText("prod-db")).toBeInTheDocument();
+    expect(screen.getByText("dev-db")).toBeInTheDocument();
   });
 
-  it('renders engine info', () => {
+  it("renders engine info", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('mysql')).toBeInTheDocument();
-    expect(screen.getByText('8.0')).toBeInTheDocument();
-    expect(screen.getByText('postgres')).toBeInTheDocument();
-    expect(screen.getByText('15.3')).toBeInTheDocument();
+    expect(screen.getByText("mysql")).toBeInTheDocument();
+    expect(screen.getByText("8.0")).toBeInTheDocument();
+    expect(screen.getByText("postgres")).toBeInTheDocument();
+    expect(screen.getByText("15.3")).toBeInTheDocument();
   });
 
-  it('renders instance classes', () => {
+  it("renders instance classes", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('db.t3.medium')).toBeInTheDocument();
-    expect(screen.getByText('db.t3.small')).toBeInTheDocument();
+    expect(screen.getByText("db.t3.medium")).toBeInTheDocument();
+    expect(screen.getByText("db.t3.small")).toBeInTheDocument();
   });
 
-  it('renders storage info', () => {
+  it("renders storage info", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('100 GB')).toBeInTheDocument();
-    expect(screen.getByText('50 GB')).toBeInTheDocument();
+    expect(screen.getByText("100 GB")).toBeInTheDocument();
+    expect(screen.getByText("50 GB")).toBeInTheDocument();
   });
 
-  it('renders multi-AZ status', () => {
+  it("renders multi-AZ status", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+    expect(screen.getByText("No")).toBeInTheDocument();
   });
 
-  it('renders terraform badges', () => {
+  it("renders terraform badges", () => {
     render(<RDSListPage />);
-    const managedBadges = screen.getAllByText('Managed');
-    const unmanagedBadges = screen.getAllByText('Unmanaged');
+    const managedBadges = screen.getAllByText("Managed");
+    const unmanagedBadges = screen.getAllByText("Unmanaged");
     expect(managedBadges.length).toBeGreaterThan(0);
     expect(unmanagedBadges.length).toBeGreaterThan(0);
   });
 
-  it('renders table headers', () => {
+  it("renders table headers", () => {
     render(<RDSListPage />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Engine')).toBeInTheDocument();
-    expect(screen.getByText('Class')).toBeInTheDocument();
-    expect(screen.getByText('Storage')).toBeInTheDocument();
-    expect(screen.getByText('Multi-AZ')).toBeInTheDocument();
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
-    expect(screen.getByText('Updated')).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Engine")).toBeInTheDocument();
+    expect(screen.getByText("Class")).toBeInTheDocument();
+    expect(screen.getByText("Storage")).toBeInTheDocument();
+    expect(screen.getByText("Multi-AZ")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockIsLoading = true;
     mockData = null as unknown as typeof mockData;
     const { container } = render(<RDSListPage />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
-    mockError = new Error('Failed to fetch');
+  it("shows error state", () => {
+    mockError = new Error("Failed to fetch");
     mockData = null as unknown as typeof mockData;
     render(<RDSListPage />);
-    expect(screen.getByText('Error loading RDS instances')).toBeInTheDocument();
+    expect(screen.getByText("Error loading RDS instances")).toBeInTheDocument();
   });
 
-  it('shows empty state when no databases', () => {
+  it("shows empty state when no databases", () => {
     mockData = { data: [], meta: { total: 0 } };
     render(<RDSListPage />);
-    expect(screen.getByText('No RDS databases found')).toBeInTheDocument();
+    expect(screen.getByText("No RDS databases found")).toBeInTheDocument();
   });
 
-  it('renders resource filters', () => {
+  it("renders resource filters", () => {
     render(<RDSListPage />);
-    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search by name or ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RDSList.tsx
+++ b/frontend/src/pages/RDSList.tsx
@@ -145,7 +145,9 @@ export function RDSListPage() {
           <Database className="h-6 w-6 text-purple-600 dark:text-purple-400" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">RDS Databases</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            RDS Databases
+          </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Amazon Relational Database Service instances
           </p>

--- a/frontend/src/pages/Terraform.test.tsx
+++ b/frontend/src/pages/Terraform.test.tsx
@@ -1,56 +1,63 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { TerraformPage } from './Terraform';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { TerraformPage } from "./Terraform";
 
 const mockStates = [
   {
-    name: 'production',
-    key: 'prod/terraform.tfstate',
+    name: "production",
+    key: "prod/terraform.tfstate",
     resource_count: 25,
-    status: 'synced',
-    last_modified: '2024-01-15T12:00:00Z',
-    description: 'Production infrastructure',
+    status: "synced",
+    last_modified: "2024-01-15T12:00:00Z",
+    description: "Production infrastructure",
   },
   {
-    name: 'development',
-    key: 'dev/terraform.tfstate',
+    name: "development",
+    key: "dev/terraform.tfstate",
     resource_count: 10,
-    status: 'synced',
-    last_modified: '2024-01-14T12:00:00Z',
+    status: "synced",
+    last_modified: "2024-01-14T12:00:00Z",
   },
 ];
 
 const mockDriftItems = [
   {
-    resource_id: 'i-123456',
-    resource_type: 'aws_instance',
-    drift_type: 'unmanaged' as const,
-    details: 'Instance not in Terraform state',
+    resource_id: "i-123456",
+    resource_type: "aws_instance",
+    drift_type: "unmanaged" as const,
+    details: "Instance not in Terraform state",
   },
   {
-    resource_id: 'sg-789012',
-    resource_type: 'aws_security_group',
-    drift_type: 'orphaned' as const,
-    details: 'Security group deleted from AWS',
+    resource_id: "sg-789012",
+    resource_type: "aws_security_group",
+    drift_type: "orphaned" as const,
+    details: "Security group deleted from AWS",
   },
 ];
 
-let mockStatesData: { states: typeof mockStates; total_tf_managed_resources: number } | null = {
+let mockStatesData: {
+  states: typeof mockStates;
+  total_tf_managed_resources: number;
+} | null = {
   states: mockStates,
   total_tf_managed_resources: 35,
 };
 let mockStatesLoading = false;
 let mockStatesError: Error | null = null;
 
-let mockDriftData: { drift_detected: boolean; items: typeof mockDriftItems; checked_at: string } | null = {
+let mockDriftData: {
+  drift_detected: boolean;
+  items: typeof mockDriftItems;
+  checked_at: string;
+} | null = {
   drift_detected: true,
   items: mockDriftItems,
-  checked_at: '2024-01-15T12:00:00Z',
+  checked_at: "2024-01-15T12:00:00Z",
 };
 let mockDriftLoading = false;
 const mockRefetchDrift = vi.fn();
 
-vi.mock('@/hooks', () => ({
+vi.mock("@/hooks", () => ({
   useTerraformStates: () => ({
     data: mockStatesData,
     isLoading: mockStatesLoading,
@@ -63,7 +70,7 @@ vi.mock('@/hooks', () => ({
   }),
 }));
 
-describe('TerraformPage', () => {
+describe("TerraformPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockStatesData = { states: mockStates, total_tf_managed_resources: 35 };
@@ -72,126 +79,132 @@ describe('TerraformPage', () => {
     mockDriftData = {
       drift_detected: true,
       items: mockDriftItems,
-      checked_at: '2024-01-15T12:00:00Z',
+      checked_at: "2024-01-15T12:00:00Z",
     };
     mockDriftLoading = false;
   });
 
-  it('renders page title', () => {
+  it("renders page title", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Terraform')).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
   });
 
-  it('renders page description', () => {
+  it("renders page description", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Manage and monitor your Terraform state files')).toBeInTheDocument();
+    expect(
+      screen.getByText("Manage and monitor your Terraform state files"),
+    ).toBeInTheDocument();
   });
 
-  it('renders state files count', () => {
+  it("renders state files count", () => {
     render(<TerraformPage />);
     // There's a card header and a card title both with "State Files"
-    const stateFilesElements = screen.getAllByText('State Files');
+    const stateFilesElements = screen.getAllByText("State Files");
     expect(stateFilesElements.length).toBeGreaterThan(0);
   });
 
-  it('renders managed resources count', () => {
+  it("renders managed resources count", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Managed Resources')).toBeInTheDocument();
-    expect(screen.getByText('35')).toBeInTheDocument();
+    expect(screen.getByText("Managed Resources")).toBeInTheDocument();
+    expect(screen.getByText("35")).toBeInTheDocument();
   });
 
-  it('renders drift items count', () => {
+  it("renders drift items count", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Drift Items')).toBeInTheDocument();
+    expect(screen.getByText("Drift Items")).toBeInTheDocument();
   });
 
-  it('renders state file names', () => {
+  it("renders state file names", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('production')).toBeInTheDocument();
-    expect(screen.getByText('development')).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
+    expect(screen.getByText("development")).toBeInTheDocument();
   });
 
-  it('renders state file keys', () => {
+  it("renders state file keys", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('prod/terraform.tfstate')).toBeInTheDocument();
-    expect(screen.getByText('dev/terraform.tfstate')).toBeInTheDocument();
+    expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
+    expect(screen.getByText("dev/terraform.tfstate")).toBeInTheDocument();
   });
 
-  it('renders resource counts', () => {
+  it("renders resource counts", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('25 resources')).toBeInTheDocument();
-    expect(screen.getByText('10 resources')).toBeInTheDocument();
+    expect(screen.getByText("25 resources")).toBeInTheDocument();
+    expect(screen.getByText("10 resources")).toBeInTheDocument();
   });
 
-  it('renders state file description when available', () => {
+  it("renders state file description when available", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Production infrastructure')).toBeInTheDocument();
+    expect(screen.getByText("Production infrastructure")).toBeInTheDocument();
   });
 
-  it('renders drift detection section', () => {
+  it("renders drift detection section", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Drift Detection')).toBeInTheDocument();
+    expect(screen.getByText("Drift Detection")).toBeInTheDocument();
   });
 
-  it('renders Check Drift button', () => {
+  it("renders Check Drift button", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Check Drift')).toBeInTheDocument();
+    expect(screen.getByText("Check Drift")).toBeInTheDocument();
   });
 
-  it('calls refetch when Check Drift is clicked', () => {
+  it("calls refetch when Check Drift is clicked", () => {
     render(<TerraformPage />);
-    const button = screen.getByText('Check Drift');
+    const button = screen.getByText("Check Drift");
     fireEvent.click(button);
     expect(mockRefetchDrift).toHaveBeenCalled();
   });
 
-  it('renders drift items when drift is detected', () => {
+  it("renders drift items when drift is detected", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('i-123456')).toBeInTheDocument();
-    expect(screen.getByText('sg-789012')).toBeInTheDocument();
-    expect(screen.getByText('aws_instance')).toBeInTheDocument();
-    expect(screen.getByText('aws_security_group')).toBeInTheDocument();
+    expect(screen.getByText("i-123456")).toBeInTheDocument();
+    expect(screen.getByText("sg-789012")).toBeInTheDocument();
+    expect(screen.getByText("aws_instance")).toBeInTheDocument();
+    expect(screen.getByText("aws_security_group")).toBeInTheDocument();
   });
 
-  it('renders drift type labels', () => {
+  it("renders drift type labels", () => {
     render(<TerraformPage />);
-    expect(screen.getByText('Unmanaged')).toBeInTheDocument();
-    expect(screen.getByText('Orphaned')).toBeInTheDocument();
+    expect(screen.getByText("Unmanaged")).toBeInTheDocument();
+    expect(screen.getByText("Orphaned")).toBeInTheDocument();
   });
 
-  it('shows no drift message when no drift items', () => {
+  it("shows no drift message when no drift items", () => {
     mockDriftData = {
       drift_detected: false,
       items: [],
-      checked_at: '2024-01-15T12:00:00Z',
+      checked_at: "2024-01-15T12:00:00Z",
     };
     render(<TerraformPage />);
-    expect(screen.getByText('No drift detected')).toBeInTheDocument();
+    expect(screen.getByText("No drift detected")).toBeInTheDocument();
   });
 
-  it('shows check drift message when no drift data', () => {
+  it("shows check drift message when no drift data", () => {
     mockDriftData = null;
     render(<TerraformPage />);
-    expect(screen.getByText('Click "Check Drift" to detect configuration drift')).toBeInTheDocument();
+    expect(
+      screen.getByText('Click "Check Drift" to detect configuration drift'),
+    ).toBeInTheDocument();
   });
 
-  it('shows loading state when states are loading', () => {
+  it("shows loading state when states are loading", () => {
     mockStatesLoading = true;
     mockStatesData = null;
     const { container } = render(<TerraformPage />);
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it('shows error state when states fail to load', () => {
-    mockStatesError = new Error('Failed to fetch');
+  it("shows error state when states fail to load", () => {
+    mockStatesError = new Error("Failed to fetch");
     mockStatesData = null;
     render(<TerraformPage />);
-    expect(screen.getByText('Error loading Terraform states')).toBeInTheDocument();
+    expect(
+      screen.getByText("Error loading Terraform states"),
+    ).toBeInTheDocument();
   });
 
-  it('shows no state files message when empty', () => {
+  it("shows no state files message when empty", () => {
     mockStatesData = { states: [], total_tf_managed_resources: 0 };
     render(<TerraformPage />);
-    expect(screen.getByText('No state files configured')).toBeInTheDocument();
+    expect(screen.getByText("No state files configured")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Terraform.tsx
+++ b/frontend/src/pages/Terraform.tsx
@@ -149,7 +149,9 @@ export function TerraformPage() {
           <GitBranch className="h-6 w-6 text-purple-600 dark:text-purple-400" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Terraform</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Terraform
+          </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Manage and monitor your Terraform state files
           </p>

--- a/frontend/src/pages/TopologyPage.test.tsx
+++ b/frontend/src/pages/TopologyPage.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { TopologyPage } from './TopologyPage';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { TopologyPage } from "./TopologyPage";
 
 // Mock the InfrastructureTopology component
 interface TopologyNodeData {
@@ -10,22 +10,26 @@ interface TopologyNodeData {
   [key: string]: unknown;
 }
 
-vi.mock('@/components/topology', () => ({
-  InfrastructureTopology: ({ onResourceSelect }: { onResourceSelect: (data: TopologyNodeData) => void }) => (
+vi.mock("@/components/topology", () => ({
+  InfrastructureTopology: ({
+    onResourceSelect,
+  }: {
+    onResourceSelect: (data: TopologyNodeData) => void;
+  }) => (
     <div data-testid="infrastructure-topology">
       <button
         data-testid="ec2-node"
         onClick={() =>
           onResourceSelect({
-            type: 'ec2',
-            label: 'web-server-1',
-            instanceId: 'i-123',
-            instanceType: 't3.micro',
-            privateIp: '10.0.1.100',
-            publicIp: '54.1.2.3',
-            privateDns: 'ip-10-0-1-100.ec2.internal',
-            publicDns: 'ec2-54-1-2-3.compute-1.amazonaws.com',
-            state: 'running',
+            type: "ec2",
+            label: "web-server-1",
+            instanceId: "i-123",
+            instanceType: "t3.micro",
+            privateIp: "10.0.1.100",
+            publicIp: "54.1.2.3",
+            privateDns: "ip-10-0-1-100.ec2.internal",
+            publicDns: "ec2-54-1-2-3.compute-1.amazonaws.com",
+            state: "running",
             tfManaged: true,
           })
         }
@@ -36,14 +40,14 @@ vi.mock('@/components/topology', () => ({
         data-testid="rds-node"
         onClick={() =>
           onResourceSelect({
-            type: 'rds',
-            label: 'prod-database',
-            dbIdentifier: 'prod-db',
-            engine: 'mysql',
-            instanceClass: 'db.t3.medium',
-            endpoint: 'prod-db.123456.us-east-1.rds.amazonaws.com',
+            type: "rds",
+            label: "prod-database",
+            dbIdentifier: "prod-db",
+            engine: "mysql",
+            instanceClass: "db.t3.medium",
+            endpoint: "prod-db.123456.us-east-1.rds.amazonaws.com",
             port: 3306,
-            status: 'available',
+            status: "available",
             tfManaged: false,
           })
         }
@@ -54,10 +58,10 @@ vi.mock('@/components/topology', () => ({
         data-testid="vpc-node"
         onClick={() =>
           onResourceSelect({
-            type: 'vpc',
-            label: 'main-vpc',
-            vpcId: 'vpc-123',
-            cidrBlock: '10.0.0.0/16',
+            type: "vpc",
+            label: "main-vpc",
+            vpcId: "vpc-123",
+            cidrBlock: "10.0.0.0/16",
             tfManaged: true,
           })
         }
@@ -68,12 +72,12 @@ vi.mock('@/components/topology', () => ({
         data-testid="subnet-node"
         onClick={() =>
           onResourceSelect({
-            type: 'subnet',
-            label: 'public-subnet-1',
-            subnetId: 'subnet-123',
-            cidrBlock: '10.0.1.0/24',
-            subnetType: 'public',
-            availabilityZone: 'us-east-1a',
+            type: "subnet",
+            label: "public-subnet-1",
+            subnetId: "subnet-123",
+            cidrBlock: "10.0.1.0/24",
+            subnetType: "public",
+            availabilityZone: "us-east-1a",
             tfManaged: false,
           })
         }
@@ -84,9 +88,9 @@ vi.mock('@/components/topology', () => ({
         data-testid="igw-node"
         onClick={() =>
           onResourceSelect({
-            type: 'internet-gateway',
-            label: 'main-igw',
-            igwId: 'igw-123',
+            type: "internet-gateway",
+            label: "main-igw",
+            igwId: "igw-123",
             tfManaged: true,
           })
         }
@@ -97,10 +101,10 @@ vi.mock('@/components/topology', () => ({
         data-testid="nat-node"
         onClick={() =>
           onResourceSelect({
-            type: 'nat-gateway',
-            label: 'nat-gateway-1',
-            natGatewayId: 'nat-123',
-            publicIp: '54.1.2.4',
+            type: "nat-gateway",
+            label: "nat-gateway-1",
+            natGatewayId: "nat-123",
+            publicIp: "54.1.2.4",
             tfManaged: true,
           })
         }
@@ -111,110 +115,110 @@ vi.mock('@/components/topology', () => ({
   ),
 }));
 
-describe('TopologyPage', () => {
-  it('renders the topology component', () => {
+describe("TopologyPage", () => {
+  it("renders the topology component", () => {
     render(<TopologyPage />);
-    expect(screen.getByTestId('infrastructure-topology')).toBeInTheDocument();
+    expect(screen.getByTestId("infrastructure-topology")).toBeInTheDocument();
   });
 
-  it('shows EC2 details when EC2 node is clicked', () => {
+  it("shows EC2 details when EC2 node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('ec2-node'));
+    fireEvent.click(screen.getByTestId("ec2-node"));
 
-    expect(screen.getByText('EC2 Instance')).toBeInTheDocument();
-    expect(screen.getByText('web-server-1')).toBeInTheDocument();
-    expect(screen.getByText('i-123')).toBeInTheDocument();
-    expect(screen.getByText('t3.micro')).toBeInTheDocument();
-    expect(screen.getByText('10.0.1.100')).toBeInTheDocument();
-    expect(screen.getByText('54.1.2.3')).toBeInTheDocument();
-    expect(screen.getByText('running')).toBeInTheDocument();
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instance")).toBeInTheDocument();
+    expect(screen.getByText("web-server-1")).toBeInTheDocument();
+    expect(screen.getByText("i-123")).toBeInTheDocument();
+    expect(screen.getByText("t3.micro")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.100")).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('shows RDS details when RDS node is clicked', () => {
+  it("shows RDS details when RDS node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('rds-node'));
+    fireEvent.click(screen.getByTestId("rds-node"));
 
-    expect(screen.getByText('RDS Database')).toBeInTheDocument();
-    expect(screen.getByText('prod-database')).toBeInTheDocument();
-    expect(screen.getByText('prod-db')).toBeInTheDocument();
-    expect(screen.getByText('mysql')).toBeInTheDocument();
-    expect(screen.getByText('db.t3.medium')).toBeInTheDocument();
-    expect(screen.getByText('available')).toBeInTheDocument();
+    expect(screen.getByText("RDS Database")).toBeInTheDocument();
+    expect(screen.getByText("prod-database")).toBeInTheDocument();
+    expect(screen.getByText("prod-db")).toBeInTheDocument();
+    expect(screen.getByText("mysql")).toBeInTheDocument();
+    expect(screen.getByText("db.t3.medium")).toBeInTheDocument();
+    expect(screen.getByText("available")).toBeInTheDocument();
   });
 
-  it('shows VPC details when VPC node is clicked', () => {
+  it("shows VPC details when VPC node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('vpc-node'));
+    fireEvent.click(screen.getByTestId("vpc-node"));
 
-    expect(screen.getByText('VPC')).toBeInTheDocument();
-    expect(screen.getByText('main-vpc')).toBeInTheDocument();
-    expect(screen.getByText('vpc-123')).toBeInTheDocument();
-    expect(screen.getByText('10.0.0.0/16')).toBeInTheDocument();
+    expect(screen.getByText("VPC")).toBeInTheDocument();
+    expect(screen.getByText("main-vpc")).toBeInTheDocument();
+    expect(screen.getByText("vpc-123")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.0/16")).toBeInTheDocument();
   });
 
-  it('shows Subnet details when Subnet node is clicked', () => {
+  it("shows Subnet details when Subnet node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('subnet-node'));
+    fireEvent.click(screen.getByTestId("subnet-node"));
 
-    expect(screen.getByText('Subnet')).toBeInTheDocument();
-    expect(screen.getByText('public-subnet-1')).toBeInTheDocument();
-    expect(screen.getByText('subnet-123')).toBeInTheDocument();
-    expect(screen.getByText('10.0.1.0/24')).toBeInTheDocument();
-    expect(screen.getByText('public')).toBeInTheDocument();
-    expect(screen.getByText('us-east-1a')).toBeInTheDocument();
+    expect(screen.getByText("Subnet")).toBeInTheDocument();
+    expect(screen.getByText("public-subnet-1")).toBeInTheDocument();
+    expect(screen.getByText("subnet-123")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.0/24")).toBeInTheDocument();
+    expect(screen.getByText("public")).toBeInTheDocument();
+    expect(screen.getByText("us-east-1a")).toBeInTheDocument();
   });
 
-  it('shows IGW details when IGW node is clicked', () => {
+  it("shows IGW details when IGW node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('igw-node'));
+    fireEvent.click(screen.getByTestId("igw-node"));
 
-    expect(screen.getByText('Internet Gateway')).toBeInTheDocument();
-    expect(screen.getByText('main-igw')).toBeInTheDocument();
-    expect(screen.getByText('igw-123')).toBeInTheDocument();
+    expect(screen.getByText("Internet Gateway")).toBeInTheDocument();
+    expect(screen.getByText("main-igw")).toBeInTheDocument();
+    expect(screen.getByText("igw-123")).toBeInTheDocument();
   });
 
-  it('shows NAT Gateway details when NAT node is clicked', () => {
+  it("shows NAT Gateway details when NAT node is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('nat-node'));
+    fireEvent.click(screen.getByTestId("nat-node"));
 
-    expect(screen.getByText('NAT Gateway')).toBeInTheDocument();
-    expect(screen.getByText('nat-gateway-1')).toBeInTheDocument();
-    expect(screen.getByText('nat-123')).toBeInTheDocument();
-    expect(screen.getByText('54.1.2.4')).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateway")).toBeInTheDocument();
+    expect(screen.getByText("nat-gateway-1")).toBeInTheDocument();
+    expect(screen.getByText("nat-123")).toBeInTheDocument();
+    expect(screen.getByText("54.1.2.4")).toBeInTheDocument();
   });
 
-  it('closes detail panel when close button is clicked', () => {
+  it("closes detail panel when close button is clicked", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('ec2-node'));
+    fireEvent.click(screen.getByTestId("ec2-node"));
 
-    expect(screen.getByText('EC2 Instance')).toBeInTheDocument();
+    expect(screen.getByText("EC2 Instance")).toBeInTheDocument();
 
     // Find and click the close button (the X icon)
-    const closeButtons = screen.getAllByRole('button');
-    const closeButton = closeButtons.find(
-      (btn) => btn.querySelector('svg')?.classList.contains('lucide-x')
+    const closeButtons = screen.getAllByRole("button");
+    const closeButton = closeButtons.find((btn) =>
+      btn.querySelector("svg")?.classList.contains("lucide-x"),
     );
     if (closeButton) {
       fireEvent.click(closeButton);
     }
 
     // Panel should be closed
-    expect(screen.queryByText('EC2 Instance')).not.toBeInTheDocument();
+    expect(screen.queryByText("EC2 Instance")).not.toBeInTheDocument();
   });
 
-  it('shows TF badge for terraform managed resources', () => {
+  it("shows TF badge for terraform managed resources", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('ec2-node'));
+    fireEvent.click(screen.getByTestId("ec2-node"));
 
-    expect(screen.getByText('TF')).toBeInTheDocument();
+    expect(screen.getByText("TF")).toBeInTheDocument();
   });
 
-  it('does not show TF badge for unmanaged resources', () => {
+  it("does not show TF badge for unmanaged resources", () => {
     render(<TopologyPage />);
-    fireEvent.click(screen.getByTestId('rds-node'));
+    fireEvent.click(screen.getByTestId("rds-node"));
 
     // RDS in our mock is not TF managed
-    expect(screen.queryByText('TF')).not.toBeInTheDocument();
+    expect(screen.queryByText("TF")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/TopologyPage.tsx
+++ b/frontend/src/pages/TopologyPage.tsx
@@ -164,36 +164,36 @@ export function TopologyPage() {
         {/* Resource detail panel - shows when a resource is clicked */}
         {selectedResource && (
           <div className="absolute bottom-4 right-4 z-20 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg w-80">
-          {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                {getResourceTypeLabel(selectedResource.type)}
-              </span>
-              {selectedResource.tfManaged && (
-                <span className="px-1.5 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300 rounded">
-                  TF
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {getResourceTypeLabel(selectedResource.type)}
                 </span>
-              )}
+                {selectedResource.tfManaged && (
+                  <span className="px-1.5 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300 rounded">
+                    TF
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => setSelectedResource(null)}
+                className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                <X className="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" />
+              </button>
             </div>
-            <button
-              onClick={() => setSelectedResource(null)}
-              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-            >
-              <X className="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" />
-            </button>
-          </div>
 
-          {/* Details */}
-          <div className="px-4 py-2 divide-y divide-gray-100 dark:divide-gray-700">
-            {details.map((detail) => (
-              <DetailRow
-                key={detail.label}
-                label={detail.label}
-                value={detail.value}
-              />
-            ))}
-          </div>
+            {/* Details */}
+            <div className="px-4 py-2 divide-y divide-gray-100 dark:divide-gray-700">
+              {details.map((detail) => (
+                <DetailRow
+                  key={detail.label}
+                  label={detail.label}
+                  value={detail.value}
+                />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/pages/VPCPage.test.tsx
+++ b/frontend/src/pages/VPCPage.test.tsx
@@ -1,114 +1,120 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
-import { VPCPage } from './VPCPage';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { VPCPage } from "./VPCPage";
 
 // Mock all VPC list components
-vi.mock('@/components/vpc/VPCList', () => ({
+vi.mock("@/components/vpc/VPCList", () => ({
   VPCList: ({ filters }: { filters: object }) => (
     <div data-testid="vpc-list">VPC List {JSON.stringify(filters)}</div>
   ),
 }));
 
-vi.mock('@/components/vpc/SubnetList', () => ({
+vi.mock("@/components/vpc/SubnetList", () => ({
   SubnetList: ({ filters }: { filters: object }) => (
     <div data-testid="subnet-list">Subnet List {JSON.stringify(filters)}</div>
   ),
 }));
 
-vi.mock('@/components/vpc/IGWList', () => ({
+vi.mock("@/components/vpc/IGWList", () => ({
   IGWList: ({ filters }: { filters: object }) => (
     <div data-testid="igw-list">IGW List {JSON.stringify(filters)}</div>
   ),
 }));
 
-vi.mock('@/components/vpc/NATGatewayList', () => ({
+vi.mock("@/components/vpc/NATGatewayList", () => ({
   NATGatewayList: ({ filters }: { filters: object }) => (
-    <div data-testid="nat-gateway-list">NAT Gateway List {JSON.stringify(filters)}</div>
+    <div data-testid="nat-gateway-list">
+      NAT Gateway List {JSON.stringify(filters)}
+    </div>
   ),
 }));
 
-vi.mock('@/components/vpc/ElasticIPList', () => ({
+vi.mock("@/components/vpc/ElasticIPList", () => ({
   ElasticIPList: ({ filters }: { filters: object }) => (
-    <div data-testid="elastic-ip-list">Elastic IP List {JSON.stringify(filters)}</div>
+    <div data-testid="elastic-ip-list">
+      Elastic IP List {JSON.stringify(filters)}
+    </div>
   ),
 }));
 
-describe('VPCPage', () => {
-  it('renders page title', () => {
+describe("VPCPage", () => {
+  it("renders page title", () => {
     render(<VPCPage />);
-    expect(screen.getByText('VPC Network Resources')).toBeInTheDocument();
+    expect(screen.getByText("VPC Network Resources")).toBeInTheDocument();
   });
 
-  it('renders page description', () => {
+  it("renders page description", () => {
     render(<VPCPage />);
-    expect(screen.getByText('Virtual Private Cloud networking components')).toBeInTheDocument();
+    expect(
+      screen.getByText("Virtual Private Cloud networking components"),
+    ).toBeInTheDocument();
   });
 
-  it('renders tab navigation', () => {
+  it("renders tab navigation", () => {
     render(<VPCPage />);
-    expect(screen.getByText('VPCs')).toBeInTheDocument();
-    expect(screen.getByText('Subnets')).toBeInTheDocument();
-    expect(screen.getByText('Internet Gateways')).toBeInTheDocument();
-    expect(screen.getByText('NAT Gateways')).toBeInTheDocument();
-    expect(screen.getByText('Elastic IPs')).toBeInTheDocument();
+    expect(screen.getByText("VPCs")).toBeInTheDocument();
+    expect(screen.getByText("Subnets")).toBeInTheDocument();
+    expect(screen.getByText("Internet Gateways")).toBeInTheDocument();
+    expect(screen.getByText("NAT Gateways")).toBeInTheDocument();
+    expect(screen.getByText("Elastic IPs")).toBeInTheDocument();
   });
 
-  it('shows VPCs tab content by default', () => {
+  it("shows VPCs tab content by default", () => {
     render(<VPCPage />);
-    expect(screen.getByTestId('vpc-list')).toBeInTheDocument();
+    expect(screen.getByTestId("vpc-list")).toBeInTheDocument();
   });
 
-  it('switches to Subnets tab when clicked', () => {
+  it("switches to Subnets tab when clicked", () => {
     render(<VPCPage />);
 
-    fireEvent.click(screen.getByText('Subnets'));
+    fireEvent.click(screen.getByText("Subnets"));
 
-    expect(screen.getByTestId('subnet-list')).toBeInTheDocument();
-    expect(screen.queryByTestId('vpc-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId("subnet-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("vpc-list")).not.toBeInTheDocument();
   });
 
-  it('switches to Internet Gateways tab when clicked', () => {
+  it("switches to Internet Gateways tab when clicked", () => {
     render(<VPCPage />);
 
-    fireEvent.click(screen.getByText('Internet Gateways'));
+    fireEvent.click(screen.getByText("Internet Gateways"));
 
-    expect(screen.getByTestId('igw-list')).toBeInTheDocument();
+    expect(screen.getByTestId("igw-list")).toBeInTheDocument();
   });
 
-  it('switches to NAT Gateways tab when clicked', () => {
+  it("switches to NAT Gateways tab when clicked", () => {
     render(<VPCPage />);
 
-    fireEvent.click(screen.getByText('NAT Gateways'));
+    fireEvent.click(screen.getByText("NAT Gateways"));
 
-    expect(screen.getByTestId('nat-gateway-list')).toBeInTheDocument();
+    expect(screen.getByTestId("nat-gateway-list")).toBeInTheDocument();
   });
 
-  it('switches to Elastic IPs tab when clicked', () => {
+  it("switches to Elastic IPs tab when clicked", () => {
     render(<VPCPage />);
 
-    fireEvent.click(screen.getByText('Elastic IPs'));
+    fireEvent.click(screen.getByText("Elastic IPs"));
 
-    expect(screen.getByTestId('elastic-ip-list')).toBeInTheDocument();
+    expect(screen.getByTestId("elastic-ip-list")).toBeInTheDocument();
   });
 
-  it('renders network icon', () => {
+  it("renders network icon", () => {
     const { container } = render(<VPCPage />);
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
   });
 
-  it('can switch between tabs multiple times', () => {
+  it("can switch between tabs multiple times", () => {
     render(<VPCPage />);
 
     // Start with VPCs
-    expect(screen.getByTestId('vpc-list')).toBeInTheDocument();
+    expect(screen.getByTestId("vpc-list")).toBeInTheDocument();
 
     // Go to Subnets
-    fireEvent.click(screen.getByText('Subnets'));
-    expect(screen.getByTestId('subnet-list')).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Subnets"));
+    expect(screen.getByTestId("subnet-list")).toBeInTheDocument();
 
     // Go back to VPCs
-    fireEvent.click(screen.getByText('VPCs'));
-    expect(screen.getByTestId('vpc-list')).toBeInTheDocument();
+    fireEvent.click(screen.getByText("VPCs"));
+    expect(screen.getByTestId("vpc-list")).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,6 @@
-import '@testing-library/jest-dom';
-import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
 
 // Cleanup after each test
 afterEach(() => {
@@ -8,7 +8,7 @@ afterEach(() => {
 });
 
 // Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: vi.fn().mockImplementation((query) => ({
     matches: false,
@@ -29,7 +29,7 @@ const localStorageMock = {
   removeItem: vi.fn(),
   clear: vi.fn(),
 };
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
 });
 

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { ReactElement } from 'react';
-import { render, RenderOptions } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider } from '@/contexts/ThemeContext';
+import React, { ReactElement } from "react";
+import { render, RenderOptions } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -29,8 +29,8 @@ function AllTheProviders({ children }: AllTheProvidersProps) {
 
 const customRender = (
   ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>
+  options?: Omit<RenderOptions, "wrapper">,
 ) => render(ui, { wrapper: AllTheProviders, ...options });
 
-export * from '@testing-library/react';
+export * from "@testing-library/react";
 export { customRender as render };


### PR DESCRIPTION
## Summary
This PR applies code formatting updates across the frontend test suite and removes the deprecated ESLint flat config environment variable from the CI workflow.

## Key Changes

- **ESLint Configuration**: Removed `ESLINT_USE_FLAT_CONFIG: false` environment variable from the frontend-tests workflow, allowing ESLint to use its default flat config mode
- **Code Formatting**: Applied Prettier formatting to all test files in the frontend, converting:
  - Single quotes to double quotes throughout
  - Improved line wrapping for better readability
  - Consistent spacing and indentation across test files

## Files Modified

- `.github/workflows/frontend-tests.yml` - Removed ESLint flat config flag
- `frontend/src/App.test.tsx` - Formatting updates
- `frontend/src/api/client.test.ts` - Formatting updates
- `frontend/src/components/common/Button.test.tsx` - Formatting updates
- `frontend/src/components/common/Card.test.tsx` - Formatting updates
- `frontend/src/components/common/EmptyState.test.tsx` - Formatting updates
- `frontend/src/components/common/Loading.test.tsx` - Formatting updates
- `frontend/src/components/common/SearchInput.test.tsx` - Formatting updates
- Additional test files (52+ files total)

## Notes

These are purely formatting and configuration changes with no functional impact on the codebase. All tests maintain their original behavior and assertions.

https://claude.ai/code/session_01AyXowtP1EuEENYr8HdEKkc