### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/backend-tests.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.11'
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/frontend-tests.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '18'
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/infrastructure.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   TF_VERSION: '1.6.0'
 
@@ -100,6 +103,9 @@ jobs:
   checkov:
     name: Checkov Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
This PR adds explicit `permissions` declarations to GitHub Actions workflows to follow the principle of least privilege and improve security posture.

## Key Changes
- Added `permissions: { contents: read }` to workflow-level permissions in:
  - `backend-tests.yml`
  - `frontend-tests.yml`
  - `infrastructure.yml`
- Added job-level permissions to the `checkov` job in `infrastructure.yml`:
  - `contents: read` - required for checking out code
  - `security-events: write` - required for publishing security scan results

## Implementation Details
These changes follow GitHub's security best practices by explicitly declaring the minimum required permissions for each workflow and job. This prevents workflows from having unnecessary access to repository resources and limits the blast radius in case of credential compromise.

The `security-events: write` permission is specifically needed for the Checkov security scanning job to report findings back to GitHub's security tab.

https://claude.ai/code/session_01EDG8s7SNgqc5YQATb9ESo1