### PR TITLE
Add ec2:DescribeRouteTables permission and warning for missing route tables

### DIFF
--- a/backend/app/collectors/subnet.py
+++ b/backend/app/collectors/subnet.py
@@ -36,6 +36,12 @@ class SubnetCollector(BaseCollector):
         if route_tables is None:
             route_tables = await self._collect_route_tables()
 
+        if not route_tables:
+            logger.warning(
+                "No route tables found - all subnets will be classified as 'unknown'. "
+                "Verify IAM permissions include ec2:DescribeRouteTables."
+            )
+
         try:
             ec2 = self._get_client("ec2")
             paginator = ec2.get_paginator("describe_subnets")

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -187,6 +187,7 @@ resource "aws_iam_role_policy" "ecs_task_aws_access" {
           "ec2:DescribeTags",
           "ec2:DescribeVpcs",
           "ec2:DescribeSubnets",
+          "ec2:DescribeRouteTables",
           "ec2:DescribeNatGateways",
           "ec2:DescribeAddresses",
           "ec2:DescribeInternetGateways"


### PR DESCRIPTION
## Summary
This PR adds the missing `ec2:DescribeRouteTables` IAM permission and implements a warning when route tables cannot be retrieved during subnet collection.

## Changes
- **IAM Policy**: Added `ec2:DescribeRouteTables` permission to the ECS task role policy to allow the collector to query route table information
- **Subnet Collector**: Added a warning log message when no route tables are found, informing users that subnets will be classified as 'unknown' and suggesting they verify IAM permissions

## Implementation Details
The warning message is logged before attempting to describe subnets, providing clear guidance to users when the route table collection fails. This helps with troubleshooting permission issues and sets proper expectations about subnet classification when route table data is unavailable.

https://claude.ai/code/session_014tfPrjqQg21ujCL3QtTLBq