### PR TITLE
Add app_version output to ECS build workflow

### DIFF
--- a/.github/workflows/ecs-build.yml
+++ b/.github/workflows/ecs-build.yml
@@ -64,6 +64,7 @@ jobs:
       backend: ${{ steps.changes.outputs.backend }}
       frontend: ${{ steps.changes.outputs.frontend }}
       environment: ${{ steps.env.outputs.environment }}
+      app_version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This change adds the `app_version` output to the ECS build workflow's outputs, making the version information available to downstream jobs that depend on this workflow.

## Key Changes
- Added `app_version: ${{ steps.version.outputs.version }}` to the workflow outputs
- This exposes the version generated by the `steps.version` step to any jobs that call this workflow

## Implementation Details
The `app_version` output is derived from `steps.version.outputs.version`, which suggests there is a version generation step earlier in the workflow that computes or retrieves the application version. By adding this to the outputs section, other jobs in the same workflow or dependent workflows can now access this version information for deployment, tagging, or other downstream processes.

https://claude.ai/code/session_01BfR9WZXfWEs8km6S4fGw3j