### PR TITLE
Group Terraform state files by bucket with expandable UI

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -97,7 +97,7 @@ export function Header() {
 
                 {/* Dropdown menu */}
                 {isUserMenuOpen && (
-                  <div className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-800 dark:ring-gray-700">
+                  <div className="absolute right-0 z-50 mt-2 w-56 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-800 dark:ring-gray-700">
                     <div className="border-b border-gray-100 px-4 py-3 dark:border-gray-700">
                       <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                         {user.display_name || user.username}

--- a/frontend/src/components/settings/TerraformBucketsSettings.tsx
+++ b/frontend/src/components/settings/TerraformBucketsSettings.tsx
@@ -73,9 +73,17 @@ export function TerraformBucketsSettings() {
   };
 
   const handleToggleEnabled = async (bucket: TerraformBucket) => {
+    const newEnabled = !bucket.enabled;
+    // Optimistically update the UI
+    setBuckets((prev) =>
+      prev.map((b) =>
+        b.id === bucket.id ? { ...b, enabled: newEnabled } : b,
+      ),
+    );
+    setError(null);
     try {
       const updated = await updateTerraformBucket(bucket.id, {
-        enabled: !bucket.enabled,
+        enabled: newEnabled,
       });
       setBuckets((prev) =>
         prev.map((b) =>
@@ -83,7 +91,21 @@ export function TerraformBucketsSettings() {
         ),
       );
     } catch {
-      setError("Failed to update bucket");
+      // Reload to get actual server state rather than blindly reverting,
+      // since the backend may have committed the change before the
+      // response failed.
+      try {
+        const data = await getTerraformBuckets();
+        setBuckets(data.buckets);
+      } catch {
+        // If reload also fails, revert optimistic update
+        setBuckets((prev) =>
+          prev.map((b) =>
+            b.id === bucket.id ? { ...b, enabled: bucket.enabled } : b,
+          ),
+        );
+        setError("Failed to update bucket");
+      }
     }
   };
 

--- a/frontend/src/pages/Terraform.test.tsx
+++ b/frontend/src/pages/Terraform.test.tsx
@@ -6,6 +6,7 @@ const mockStates = [
   {
     name: "production",
     key: "prod/terraform.tfstate",
+    bucket: { name: "my-tf-bucket", region: "us-east-1" },
     resource_count: 25,
     status: "synced",
     last_modified: "2024-01-15T12:00:00Z",
@@ -14,9 +15,11 @@ const mockStates = [
   {
     name: "development",
     key: "dev/terraform.tfstate",
+    bucket: { name: "my-tf-bucket", region: "us-east-1" },
     resource_count: 10,
     status: "synced",
     last_modified: "2024-01-14T12:00:00Z",
+    description: null,
   },
 ];
 
@@ -114,27 +117,31 @@ describe("TerraformPage", () => {
     expect(screen.getByText("Drift Items")).toBeInTheDocument();
   });
 
-  it("renders state file names", () => {
+  it("renders bucket group header", () => {
     render(<TerraformPage />);
+    expect(screen.getByText("my-tf-bucket")).toBeInTheDocument();
+    expect(screen.getByText("2 state files")).toBeInTheDocument();
+  });
+
+  it("renders state file names after expanding bucket", () => {
+    render(<TerraformPage />);
+    fireEvent.click(screen.getByText("my-tf-bucket"));
     expect(screen.getByText("production")).toBeInTheDocument();
     expect(screen.getByText("development")).toBeInTheDocument();
   });
 
-  it("renders state file keys", () => {
+  it("renders state file keys after expanding bucket", () => {
     render(<TerraformPage />);
+    fireEvent.click(screen.getByText("my-tf-bucket"));
     expect(screen.getByText("prod/terraform.tfstate")).toBeInTheDocument();
     expect(screen.getByText("dev/terraform.tfstate")).toBeInTheDocument();
   });
 
-  it("renders resource counts", () => {
+  it("renders resource counts after expanding bucket", () => {
     render(<TerraformPage />);
+    fireEvent.click(screen.getByText("my-tf-bucket"));
     expect(screen.getByText("25 resources")).toBeInTheDocument();
     expect(screen.getByText("10 resources")).toBeInTheDocument();
-  });
-
-  it("renders state file description when available", () => {
-    render(<TerraformPage />);
-    expect(screen.getByText("Production infrastructure")).toBeInTheDocument();
   });
 
   it("renders drift detection section", () => {

--- a/frontend/src/types/resources.ts
+++ b/frontend/src/types/resources.ts
@@ -225,9 +225,15 @@ export interface RefreshResponse {
 // Terraform Types
 // =============================================================================
 
+export interface TerraformBucketInfo {
+  name: string;
+  region: string | null;
+}
+
 export interface TerraformStateInfo {
   name: string;
   key: string;
+  bucket: TerraformBucketInfo | null;
   description: string | null;
   last_modified: string | null;
   resource_count: number;


### PR DESCRIPTION
## Summary
Refactored the Terraform state files display to group states by their parent bucket with an expandable/collapsible UI, improving organization and readability when managing multiple buckets.

## Key Changes

- **State file grouping**: States are now grouped by bucket name and region, with a count of state files and total resources per bucket
- **Expandable bucket cards**: Added toggle functionality to expand/collapse state files within each bucket group, reducing visual clutter
- **UI component refactoring**: 
  - Renamed `StateFileCard` to `StateFileRow` and simplified to a compact row layout
  - Created new `BucketGroupCard` component to display bucket headers with expansion controls
  - Added chevron icons to indicate expanded/collapsed state
- **Type updates**: Added `TerraformBucketInfo` interface and `bucket` field to `TerraformStateInfo`
- **Test updates**: Updated test mocks and assertions to reflect the new bucket grouping structure and expansion behavior
- **Bug fixes**:
  - Added `z-50` to user menu dropdown to fix stacking context issues
  - Improved error handling in `handleToggleEnabled` to reload server state on failure rather than blindly reverting
- **Minor improvements**: Updated icon sizes and spacing for better visual hierarchy in the new row-based layout

## Implementation Details

The bucket grouping uses a `useMemo` hook to efficiently organize states by bucket name, calculating totals for resource counts. Expanded/collapsed state is managed via a `Set<string>` to track which buckets are open, allowing users to focus on specific buckets while keeping others collapsed.

https://claude.ai/code/session_011D88LK1wZomteci8DbMPFY