### PR TITLE
Replace static Terraform state bucket with dynamic S3 access

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -202,9 +202,6 @@ module "ecs" {
   secrets_arns          = module.secrets.all_secret_arns
   enable_secrets_access = true
 
-  # Terraform state access
-  tf_state_bucket_arn = var.tf_state_bucket != "" ? "arn:aws:s3:::${var.tf_state_bucket}" : ""
-
   # Logging
   log_retention_days        = 7 # Shorter retention for dev
   enable_container_insights = false

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -200,9 +200,6 @@ module "ecs" {
   secrets_arns          = module.secrets.all_secret_arns
   enable_secrets_access = true
 
-  # Terraform state access
-  tf_state_bucket_arn = var.tf_state_bucket != "" ? "arn:aws:s3:::${var.tf_state_bucket}" : ""
-
   # Logging
   log_retention_days        = 90
   enable_container_insights = true

--- a/infrastructure/modules/ecs/variables.tf
+++ b/infrastructure/modules/ecs/variables.tf
@@ -122,15 +122,6 @@ variable "enable_secrets_access" {
   default     = false
 }
 
-# -----------------------------------------------------------------------------
-# S3/Terraform State Access
-# -----------------------------------------------------------------------------
-
-variable "tf_state_bucket_arn" {
-  description = "ARN of the Terraform state S3 bucket"
-  type        = string
-  default     = ""
-}
 
 # -----------------------------------------------------------------------------
 # Logging


### PR DESCRIPTION
## Summary
This PR removes the static Terraform state bucket configuration and replaces it with a dynamic, account-scoped S3 access policy. This allows ECS tasks to read Terraform state files from any S3 bucket within the AWS account, enabling buckets to be added via the Settings UI without requiring infrastructure changes.

## Key Changes
- **Removed static bucket configuration**: Deleted `tf_state_bucket_arn` variable from the ECS module and removed its usage from dev and prod environment configurations
- **Implemented dynamic S3 access policy**: Updated the IAM policy to use wildcard S3 ARNs (`arn:aws:s3:::*/*` and `arn:aws:s3:::*`) with account-level conditions instead of a single pre-configured bucket
- **Split S3 permissions**: Separated the policy into two statements:
  - `S3TerraformStateReadObjects`: Allows `s3:GetObject` on all objects within the account
  - `S3TerraformStateListBuckets`: Allows `s3:ListBucket` on all buckets within the account
- **Added account scoping**: Both statements include a condition that restricts access to resources owned by the current AWS account using `s3:ResourceAccount`

## Implementation Details
- The policy now uses `data.aws_caller_identity.current.account_id` to dynamically scope permissions to the current account, preventing cross-account access
- Removed the conditional count logic (`count = var.tf_state_bucket_arn != "" ? 1 : 0`) since the policy is now always created
- This approach maintains security by limiting access to the current AWS account while providing flexibility for bucket management through the Settings UI

https://claude.ai/code/session_01LNMvZuik6e2yy4qUJQJ1fi