### PR TITLE
Raise header z-index to z-30 so dropdown appears above topology canvas

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -51,7 +51,7 @@ export function Header() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <header className="sticky top-0 z-30 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
         <div className="flex h-16 items-center justify-between">
           <div className="flex items-center gap-3 pl-4">
             <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900">


### PR DESCRIPTION
The header was z-10, same as the React Flow topology overlay elements. Since the dropdown is a child of the header's stacking context, its z-50 couldn't escape the z-10 ceiling. Raising the header to z-30 ensures the user menu renders above all page content.

https://claude.ai/code/session_011D88LK1wZomteci8DbMPFY