### PR TITLE
Add ECS read-only IAM permissions for container discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,9 @@ See `.env.example` for complete list. Key variables:
         "ec2:DescribeNatGateways",
         "ec2:DescribeAddresses",
         "rds:DescribeDBInstances",
+        "ecs:ListClusters",
+        "ecs:ListTasks",
+        "ecs:DescribeTasks",
         "s3:GetObject",
         "s3:ListBucket"
       ],

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -170,7 +170,7 @@ resource "aws_iam_role" "ecs_task" {
   tags = var.tags
 }
 
-# Policy for AWS API access (EC2, RDS read-only)
+# Policy for AWS API access (EC2, RDS, ECS read-only)
 resource "aws_iam_role_policy" "ecs_task_aws_access" {
   name = "aws-api-access"
   role = aws_iam_role.ecs_task.id
@@ -201,6 +201,16 @@ resource "aws_iam_role_policy" "ecs_task_aws_access" {
           "rds:DescribeDBInstances",
           "rds:DescribeDBClusters",
           "rds:ListTagsForResource"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECSReadAccess"
+        Effect = "Allow"
+        Action = [
+          "ecs:ListClusters",
+          "ecs:ListTasks",
+          "ecs:DescribeTasks"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
The new ECS collector requires ecs:ListClusters, ecs:ListTasks, and ecs:DescribeTasks permissions to discover and display ECS containers in the topology view.

https://claude.ai/code/session_015rsK2rRr3uW3r15YQdbdrW