### PR TITLE
Add ECS Containers page with sidebar navigation and detail panel

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/pages", () => ({
   ),
   EC2ListPage: () => <div data-testid="ec2-page">EC2 Content</div>,
   RDSListPage: () => <div data-testid="rds-page">RDS Content</div>,
+  ECSListPage: () => <div data-testid="ecs-page">ECS Content</div>,
   VPCPage: () => <div data-testid="vpc-page">VPC Content</div>,
   TerraformPage: () => (
     <div data-testid="terraform-page">Terraform Content</div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   DashboardPage,
   EC2ListPage,
   RDSListPage,
+  ECSListPage,
   VPCPage,
   TerraformPage,
   TopologyPage,
@@ -52,6 +53,7 @@ function App() {
                 <Route index element={<DashboardPage />} />
                 <Route path="ec2" element={<EC2ListPage />} />
                 <Route path="rds" element={<RDSListPage />} />
+                <Route path="ecs" element={<ECSListPage />} />
                 <Route path="vpc" element={<VPCPage />} />
                 <Route path="terraform" element={<TerraformPage />} />
                 <Route path="topology" element={<TopologyPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   LayoutDashboard,
   Server,
   Database,
+  Container,
   Network,
   GitBranch,
   Waypoints,
@@ -15,6 +16,7 @@ const navigation = [
   { name: "Topology", href: "/topology", icon: Waypoints },
   { name: "EC2 Instances", href: "/ec2", icon: Server },
   { name: "RDS Databases", href: "/rds", icon: Database },
+  { name: "ECS Containers", href: "/ecs", icon: Container },
   { name: "VPC Networking", href: "/vpc", icon: Network },
   { name: "Terraform", href: "/terraform", icon: GitBranch },
 ];

--- a/frontend/src/components/resources/ResourceDetailPanel.tsx
+++ b/frontend/src/components/resources/ResourceDetailPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { X, Copy, Check } from "lucide-react";
 import { Button, StatusBadge, TerraformBadge } from "@/components/common";
 import { formatDateTime } from "@/lib/utils";
-import type { EC2Instance, RDSInstance } from "@/types";
+import type { EC2Instance, RDSInstance, ECSContainer } from "@/types";
 
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -315,6 +315,147 @@ export function RDSDetailPanel({ instance, onClose }: RDSDetailPanelProps) {
               />
             </div>
           </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ECSDetailPanelProps {
+  container: ECSContainer;
+  onClose: () => void;
+}
+
+export function ECSDetailPanel({ container, onClose }: ECSDetailPanelProps) {
+  const formatMemory = (mb: number) =>
+    mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb} MB`;
+
+  return (
+    <div className="fixed top-16 right-0 bottom-0 z-50 !mt-0 w-96 overflow-y-auto border-l border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800">
+      <div className="sticky top-0 flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          ECS Container Details
+        </h2>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          <X className="h-5 w-5" />
+        </Button>
+      </div>
+
+      <div className="p-4">
+        <div className="mb-4 flex items-center gap-2">
+          <StatusBadge status={container.display_status} />
+          <TerraformBadge managed={container.tf_managed} />
+        </div>
+
+        <h3 className="mb-4 text-xl font-bold text-gray-900 dark:text-gray-100">
+          {container.name || container.task_id}
+        </h3>
+
+        <div className="space-y-6">
+          <section>
+            <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Basic Info
+            </h4>
+            <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+              <CopyableDetailRow label="Task ID" value={container.task_id} />
+              <DetailRow label="Cluster" value={container.cluster_name} />
+              <DetailRow label="Launch Type" value={container.launch_type} />
+              <DetailRow label="Status" value={container.status} />
+              <DetailRow
+                label="Desired Status"
+                value={container.desired_status}
+              />
+              <DetailRow label="Region" value={container.region_name} />
+              <DetailRow label="AZ" value={container.availability_zone} />
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Resources
+            </h4>
+            <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+              <DetailRow label="CPU" value={`${container.cpu} vCPU units`} />
+              <DetailRow
+                label="Memory"
+                value={formatMemory(container.memory)}
+              />
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Container
+            </h4>
+            <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+              <CopyableDetailRow label="Image" value={container.image} />
+              <DetailRow
+                label="Port"
+                value={container.container_port?.toString()}
+              />
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Network
+            </h4>
+            <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+              <CopyableDetailRow
+                label="Private IP"
+                value={container.private_ip}
+              />
+              <DetailRow label="VPC ID" value={container.vpc_id} />
+              <DetailRow label="Subnet ID" value={container.subnet_id} />
+            </div>
+          </section>
+
+          {container.tf_managed && (
+            <section>
+              <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+                Terraform
+              </h4>
+              <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+                <DetailRow
+                  label="State File"
+                  value={container.tf_state_source}
+                />
+                <DetailRow
+                  label="Address"
+                  value={container.tf_resource_address}
+                />
+              </div>
+            </section>
+          )}
+
+          <section>
+            <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Timestamps
+            </h4>
+            <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+              <DetailRow
+                label="Started"
+                value={formatDateTime(container.started_at)}
+              />
+              <DetailRow
+                label="Last Updated"
+                value={formatDateTime(container.updated_at)}
+              />
+            </div>
+          </section>
+
+          {container.tags && Object.keys(container.tags).length > 0 && (
+            <section>
+              <h4 className="mb-2 text-sm font-semibold uppercase text-gray-500 dark:text-gray-400">
+                Tags
+              </h4>
+              <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-gray-50 px-3 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-700">
+                {Object.entries(container.tags).map(([key, value]) => (
+                  <DetailRow key={key} label={key} value={value} />
+                ))}
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/resources/index.ts
+++ b/frontend/src/components/resources/index.ts
@@ -1,3 +1,7 @@
 export { ResourceTable } from "./ResourceTable";
 export { ResourceFilters } from "./ResourceFilters";
-export { EC2DetailPanel, RDSDetailPanel } from "./ResourceDetailPanel";
+export {
+  EC2DetailPanel,
+  RDSDetailPanel,
+  ECSDetailPanel,
+} from "./ResourceDetailPanel";

--- a/frontend/src/pages/ECSList.tsx
+++ b/frontend/src/pages/ECSList.tsx
@@ -1,0 +1,182 @@
+import { useState, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Container } from "lucide-react";
+import {
+  PageLoading,
+  StatusBadge,
+  TerraformBadge,
+  EmptyState,
+} from "@/components/common";
+import {
+  ResourceTable,
+  ResourceFilters,
+  ECSDetailPanel,
+} from "@/components/resources";
+import { useECSContainers } from "@/hooks";
+import { getResourceName, formatRelativeTime } from "@/lib/utils";
+import type { ResourceFilters as Filters, ECSContainer } from "@/types";
+
+export function ECSListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [filters, setFilters] = useState<Filters>({});
+
+  const selectedId = searchParams.get("selected");
+
+  const { data, isLoading, error } = useECSContainers(filters);
+
+  const selectedContainer = useMemo(() => {
+    if (!selectedId || !data?.data) return null;
+    return data.data.find((c) => c.task_id === selectedId) || null;
+  }, [selectedId, data?.data]);
+
+  const handleRowClick = (container: ECSContainer) => {
+    setSearchParams({ selected: container.task_id });
+  };
+
+  const handleCloseDetail = () => {
+    setSearchParams({});
+  };
+
+  const formatMemory = (mb: number) =>
+    mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb} MB`;
+
+  const columns = [
+    {
+      key: "name",
+      header: "Name",
+      render: (container: ECSContainer) => (
+        <div>
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            {getResourceName(container.name, container.task_id)}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {container.task_id}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (container: ECSContainer) => (
+        <StatusBadge status={container.display_status} size="sm" />
+      ),
+    },
+    {
+      key: "cluster",
+      header: "Cluster",
+      render: (container: ECSContainer) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {container.cluster_name}
+        </span>
+      ),
+    },
+    {
+      key: "launch_type",
+      header: "Launch Type",
+      render: (container: ECSContainer) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {container.launch_type}
+        </span>
+      ),
+    },
+    {
+      key: "resources",
+      header: "CPU / Memory",
+      render: (container: ECSContainer) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {container.cpu} / {formatMemory(container.memory)}
+        </span>
+      ),
+    },
+    {
+      key: "ip",
+      header: "Private IP",
+      render: (container: ECSContainer) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {container.private_ip || "-"}
+        </span>
+      ),
+    },
+    {
+      key: "terraform",
+      header: "Terraform",
+      render: (container: ECSContainer) => (
+        <TerraformBadge managed={container.tf_managed} />
+      ),
+    },
+    {
+      key: "updated",
+      header: "Updated",
+      render: (container: ECSContainer) => (
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {formatRelativeTime(container.updated_at)}
+        </span>
+      ),
+    },
+  ];
+
+  if (isLoading) {
+    return <PageLoading />;
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={<Container className="h-8 w-8" />}
+        title="Error loading ECS containers"
+        description="Failed to fetch ECS containers. Please try again."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-teal-100 dark:bg-teal-900">
+          <Container className="h-6 w-6 text-teal-600 dark:text-teal-400" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            ECS Containers
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Amazon Elastic Container Service tasks
+          </p>
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        {data?.meta.total || 0} containers found
+      </p>
+
+      <ResourceFilters filters={filters} onFilterChange={setFilters} />
+
+      {data?.data.length === 0 ? (
+        <EmptyState
+          icon={<Container className="h-8 w-8" />}
+          title="No ECS containers found"
+          description={
+            Object.keys(filters).length > 0
+              ? "Try adjusting your filters"
+              : "No ECS containers are available in your account"
+          }
+        />
+      ) : (
+        <ResourceTable
+          columns={columns}
+          data={data?.data || []}
+          keyExtractor={(container) => container.task_id}
+          onRowClick={handleRowClick}
+        />
+      )}
+
+      {selectedContainer && (
+        <ECSDetailPanel
+          container={selectedContainer}
+          onClose={handleCloseDetail}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,6 +1,7 @@
 export { DashboardPage } from "./Dashboard";
 export { EC2ListPage } from "./EC2List";
 export { RDSListPage } from "./RDSList";
+export { ECSListPage } from "./ECSList";
 export { VPCPage } from "./VPCPage";
 export { TerraformPage } from "./Terraform";
 export { TopologyPage } from "./TopologyPage";


### PR DESCRIPTION
Adds a dedicated /ecs route with a list view, detail panel, and sidebar navigation entry so ECS containers are browsable alongside EC2 and RDS. Follows the existing EC2ListPage/RDSDetailPanel patterns.

https://claude.ai/code/session_015rsK2rRr3uW3r15YQdbdrW