### PR TITLE
Fix timezone handling for API datetime strings without indicators

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -75,6 +75,17 @@ describe("formatRelativeTime", () => {
     expect(result).toContain("7 days ago");
   });
 
+  it("treats datetime strings without timezone as UTC", () => {
+    // Backend may serialize datetimes without Z suffix
+    const result = formatRelativeTime("2024-01-15T11:55:00");
+    expect(result).toContain("minutes ago");
+  });
+
+  it("handles datetime strings with +00:00 offset", () => {
+    const result = formatRelativeTime("2024-01-15T11:55:00+00:00");
+    expect(result).toContain("minutes ago");
+  });
+
   it('returns "Unknown" for invalid date string', () => {
     expect(formatRelativeTime("not-a-date")).toBe("Unknown");
   });
@@ -92,6 +103,12 @@ describe("formatDateTime", () => {
   it("formats date correctly", () => {
     const result = formatDateTime("2024-01-15T14:30:45Z");
     expect(result).toMatch(/Jan 15, 2024/);
+  });
+
+  it("treats datetime strings without timezone as UTC", () => {
+    const withZ = formatDateTime("2024-01-15T14:30:45Z");
+    const withoutZ = formatDateTime("2024-01-15T14:30:45");
+    expect(withoutZ).toBe(withZ);
   });
 
   it('returns "Invalid date" for invalid date string', () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -15,12 +15,24 @@ export function cn(...inputs: ClassValue[]) {
 // Date Utilities
 // =============================================================================
 
+/**
+ * Ensures a datetime string from the API is treated as UTC.
+ * Backend datetimes are stored in UTC but may be serialized without
+ * a timezone indicator, causing browsers to interpret them as local time.
+ */
+function ensureUtcDateString(dateString: string): string {
+  if (/[Zz]$|[+-]\d{2}:\d{2}$/.test(dateString)) {
+    return dateString;
+  }
+  return dateString + "Z";
+}
+
 export function formatRelativeTime(
   dateString: string | null | undefined,
 ): string {
   if (!dateString) return "Never";
   try {
-    const date = new Date(dateString);
+    const date = new Date(ensureUtcDateString(dateString));
     return formatDistanceToNow(date, { addSuffix: true });
   } catch {
     return "Unknown";
@@ -30,7 +42,7 @@ export function formatRelativeTime(
 export function formatDateTime(dateString: string | null | undefined): string {
   if (!dateString) return "N/A";
   try {
-    const date = new Date(dateString);
+    const date = new Date(ensureUtcDateString(dateString));
     return format(date, "MMM d, yyyy HH:mm:ss");
   } catch {
     return "Invalid date";


### PR DESCRIPTION
## Summary
Fixes an issue where datetime strings from the backend that lack timezone indicators (no `Z` suffix or `±HH:MM` offset) were being interpreted as local time instead of UTC, causing incorrect relative and absolute time displays.

## Changes
- Added `ensureUtcDateString()` utility function that appends a `Z` suffix to datetime strings that don't already have timezone information
- Updated `formatRelativeTime()` to use the new utility, ensuring consistent UTC interpretation
- Updated `formatDateTime()` to use the new utility, ensuring consistent UTC interpretation
- Added test cases to verify:
  - Datetime strings without timezone indicators are treated as UTC
  - Datetime strings with `+00:00` offset are handled correctly
  - Datetime strings with and without `Z` suffix produce identical formatted output

## Implementation Details
The `ensureUtcDateString()` function uses a regex pattern to detect existing timezone indicators (`Z`, `z`, or `±HH:MM` format) and only appends `Z` when none are present. This ensures backward compatibility with properly formatted datetime strings while fixing the interpretation of bare ISO 8601 strings from the backend.

https://claude.ai/code/session_01VGTvfoyjdnv3cQomGBbtLU