### PR TITLE
Change default AWS region from us-east-1 to us-east-2

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -21,7 +21,7 @@ terraform {
   # backend "s3" {
   #   bucket         = "your-terraform-state-bucket"
   #   key            = "aws-infra-visualizer/dev/terraform.tfstate"
-  #   region         = "us-east-1"
+  #   region         = "us-east-2"
   #   encrypt        = true
   #   dynamodb_table = "terraform-locks"
   # }

--- a/infrastructure/environments/dev/terraform.tfvars.example
+++ b/infrastructure/environments/dev/terraform.tfvars.example
@@ -6,11 +6,11 @@
 # Project settings
 project_name = "aws-infra-visualizer"
 environment  = "dev"
-aws_region   = "us-east-1"
+aws_region   = "us-east-2"
 
 # Network settings
 vpc_cidr           = "10.0.0.0/16"
-availability_zones = ["us-east-1a", "us-east-1b"]
+availability_zones = ["us-east-2a", "us-east-2b"]
 enable_nat_gateway = true
 
 # Container settings

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -21,7 +21,7 @@ variable "environment" {
 variable "aws_region" {
   description = "AWS region"
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
 }
 
 # -----------------------------------------------------------------------------
@@ -37,7 +37,7 @@ variable "vpc_cidr" {
 variable "availability_zones" {
   description = "List of availability zones"
   type        = list(string)
-  default     = ["us-east-1a", "us-east-1b"]
+  default     = ["us-east-2a", "us-east-2b"]
 }
 
 variable "enable_nat_gateway" {

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -21,7 +21,7 @@ terraform {
   # backend "s3" {
   #   bucket         = "your-terraform-state-bucket"
   #   key            = "aws-infra-visualizer/prod/terraform.tfstate"
-  #   region         = "us-east-1"
+  #   region         = "us-east-2"
   #   encrypt        = true
   #   dynamodb_table = "terraform-locks"
   # }

--- a/infrastructure/environments/prod/terraform.tfvars.example
+++ b/infrastructure/environments/prod/terraform.tfvars.example
@@ -6,11 +6,11 @@
 # Project settings
 project_name = "aws-infra-visualizer"
 environment  = "prod"
-aws_region   = "us-east-1"
+aws_region   = "us-east-2"
 
 # Network settings (3 AZs for production HA)
 vpc_cidr           = "10.1.0.0/16"
-availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
 
 # Container settings
 container_port    = 8000

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -21,7 +21,7 @@ variable "environment" {
 variable "aws_region" {
   description = "AWS region"
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
 }
 
 # -----------------------------------------------------------------------------
@@ -37,7 +37,7 @@ variable "vpc_cidr" {
 variable "availability_zones" {
   description = "List of availability zones (use 3 for production)"
   type        = list(string)
-  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
 }
 
 variable "allowed_ingress_cidrs" {


### PR DESCRIPTION
## Summary
Updates the default AWS region across all Terraform configurations from `us-east-1` to `us-east-2` for both development and production environments.

## Changes Made
- **Dev environment** (`infrastructure/environments/dev/`):
  - Updated S3 backend region in `main.tf`
  - Changed `aws_region` default in `variables.tf` and `terraform.tfvars.example`
  - Updated availability zones from `us-east-1a, us-east-1b` to `us-east-2a, us-east-2b`

- **Prod environment** (`infrastructure/environments/prod/`):
  - Updated S3 backend region in `main.tf`
  - Changed `aws_region` default in `variables.tf` and `terraform.tfvars.example`
  - Updated availability zones from `us-east-1a, us-east-1b, us-east-1c` to `us-east-2a, us-east-2b, us-east-2c`

## Implementation Details
- All changes are consistent across both environments
- Production maintains 3 availability zones for high availability
- Development maintains 2 availability zones
- Both Terraform state backend configurations and variable defaults have been updated to ensure consistency

https://claude.ai/code/session_01RyiYLah69VKhV3KPQFewjQ