### PR TITLE
Fix topology not rendering: tf_managed sync skipped for DB-configured…

### DIFF
--- a/backend/app/api/routes/resources.py
+++ b/backend/app/api/routes/resources.py
@@ -864,11 +864,13 @@ async def _sync_ecs_containers(
 
 
 async def _sync_terraform_state(db: AsyncSession) -> int:
-    """Update Terraform tracking information for resources."""
-    if not settings.tf_state_bucket:
-        logger.info("No Terraform state bucket configured, skipping TF sync")
-        return 0
+    """Update Terraform tracking information for resources.
 
+    Bucket configuration is resolved by TerraformStateAggregator which
+    checks the database (TerraformStateBucket rows) *and* the
+    TF_STATE_BUCKET env-var, so we must not bail out early based solely
+    on the env-var.
+    """
     try:
         aggregator = TerraformStateAggregator()
         tf_resources = await aggregator.aggregate_all()


### PR DESCRIPTION
… buckets

_sync_terraform_state() had an early guard that returned immediately if the TF_STATE_BUCKET env var was not set. However, Terraform state buckets can also be configured via the database (TerraformStateBucket table), which the TerraformStateAggregator already handles through _get_all_bucket_configs().

This mismatch meant the /api/terraform/states endpoint could read state files (it uses the aggregator directly), but the refresh process never marked any resources as tf_managed=True. Since the topology API filters exclusively on tf_managed=True, the view rendered empty.

Remove the env-var guard and let the aggregator resolve bucket configs from both the database and environment.

https://claude.ai/code/session_01RiLRfyGXZtPpmRXih26S4e