### PR TITLE
Fix count depending on computed task_role_arn value

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -216,7 +216,8 @@ module "ecs" {
   desired_count = 1
 
   # IAM - use the standalone application task role
-  task_role_arn = module.iam.task_role_arn
+  create_task_role = false
+  task_role_arn    = module.iam.task_role_arn
 
   # Environment and secrets
   environment_variables = local.environment_variables

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -214,7 +214,8 @@ module "ecs" {
   desired_count = 2    # Multi-AZ
 
   # IAM - use the standalone application task role
-  task_role_arn = module.iam.task_role_arn
+  create_task_role = false
+  task_role_arn    = module.iam.task_role_arn
 
   # Environment and secrets
   environment_variables = local.environment_variables

--- a/infrastructure/modules/ecs/variables.tf
+++ b/infrastructure/modules/ecs/variables.tf
@@ -200,9 +200,15 @@ variable "memory_target_value" {
 # -----------------------------------------------------------------------------
 
 variable "task_role_arn" {
-  description = "ARN of an external task role. If provided, the module will use it instead of creating its own task role with AWS API policies."
+  description = "ARN of an external task role. When create_task_role is false, this role is used for the ECS task definition."
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "create_task_role" {
+  description = "Whether to create a task role inside this module. Set to false when providing an external task_role_arn."
+  type        = bool
+  default     = true
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Replace the string comparison (var.task_role_arn == "") with a static boolean var.create_task_role for conditional resource creation. The ARN is a computed value unknown at plan time, which causes Terraform to error with "count depends on resource attributes that cannot be determined until apply".

https://claude.ai/code/session_019sFURW6ZEq13BBxtrd1CTE