### PR TITLE
Improve topology diagram spacing and edge rendering

### DIFF
--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -57,9 +57,9 @@ const config = {
   },
   spacing: {
     horizontal: 15,
-    vertical: 20,
+    vertical: 30,
     subnetGap: 20,
-    rowGap: 25,
+    rowGap: 70,
     vpcGap: 50,
   },
   resourcesPerRow: 2,
@@ -533,7 +533,8 @@ export function createEdges(data: TopologyResponse): Edge[] {
           type: "smoothstep",
           animated: true,
           style: { stroke: "#94a3b8", strokeWidth: 2 },
-          zIndex: 10,
+          zIndex: 0,
+          pathOptions: { offset: 20 },
         });
       }
     }
@@ -560,7 +561,8 @@ export function createEdges(data: TopologyResponse): Edge[] {
               strokeWidth: 2,
               strokeDasharray: "5,5",
             },
-            zIndex: 10,
+            zIndex: 0,
+            pathOptions: { offset: 25 },
           });
         }
       }


### PR DESCRIPTION
## Summary
This PR adjusts the layout spacing configuration and edge rendering properties in the topology diagram to improve visual clarity and prevent edge overlapping.

## Key Changes
- **Increased vertical spacing**: Bumped vertical spacing from 20 to 30 pixels for better node separation
- **Increased row gap**: Raised rowGap from 25 to 70 pixels to provide more breathing room between rows
- **Fixed edge layering**: Changed zIndex from 10 to 0 for both subnet and VPC edges to ensure proper rendering order
- **Added edge offsets**: Introduced `pathOptions` with offset values (20 for subnet edges, 25 for VPC edges) to prevent edges from overlapping when multiple connections exist between nodes

## Implementation Details
These changes primarily affect the `layoutCalculator.ts` file which controls the topology diagram's visual layout. The spacing adjustments provide better visual hierarchy, while the edge offset configuration uses the smoothstep edge type's pathOptions to curve edges away from each other, reducing visual clutter in dense network diagrams.

https://claude.ai/code/session_01BrehwLocNceLbt4vFRUuCc