### PR TITLE
Fix IGW-to-subnet edge overlap and reduce excessive row gap

### DIFF
--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -57,9 +57,10 @@ const config = {
   },
   spacing: {
     horizontal: 15,
-    vertical: 30,
+    vertical: 20,
     subnetGap: 20,
-    rowGap: 70,
+    rowGap: 50,
+    igwToSubnetGap: 50,
     vpcGap: 50,
   },
   resourcesPerRow: 2,
@@ -187,7 +188,7 @@ function layoutVPC(
 
   // IGW height
   if (vpc.internet_gateway) {
-    contentHeight += config.nodeHeight.gateway + config.spacing.vertical;
+    contentHeight += config.nodeHeight.gateway + config.spacing.igwToSubnetGap;
   }
 
   // Public subnets row
@@ -258,7 +259,7 @@ function layoutVPC(
         igwId: vpc.internet_gateway.id,
       } as InternetGatewayNodeData,
     });
-    relativeY += config.nodeHeight.gateway + config.spacing.vertical;
+    relativeY += config.nodeHeight.gateway + config.spacing.igwToSubnetGap;
   }
 
   // Layout public subnets (children of VPC)


### PR DESCRIPTION
Separate IGW-to-subnet spacing from resource grid spacing by adding a dedicated igwToSubnetGap (50px) so smoothstep edges with offset=20 have enough room (≥40px) to route without zigzagging through subnet headers. Revert spacing.vertical to 20px (resource grid) and reduce rowGap from 70 to 50px for better proportions.

https://claude.ai/code/session_01BrehwLocNceLbt4vFRUuCc