### PR TITLE
Smooth edge corners and raise edges above containers

### DIFF
--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -534,8 +534,8 @@ export function createEdges(data: TopologyResponse): Edge[] {
           type: "smoothstep",
           animated: true,
           style: { stroke: "#94a3b8", strokeWidth: 2 },
-          zIndex: 0,
-          pathOptions: { offset: 20 },
+          zIndex: 3,
+          pathOptions: { offset: 20, borderRadius: 20 },
         });
       }
     }
@@ -562,8 +562,8 @@ export function createEdges(data: TopologyResponse): Edge[] {
               strokeWidth: 2,
               strokeDasharray: "5,5",
             },
-            zIndex: 0,
-            pathOptions: { offset: 25 },
+            zIndex: 3,
+            pathOptions: { offset: 25, borderRadius: 20 },
           });
         }
       }


### PR DESCRIPTION
Increase smoothstep borderRadius from 5 to 20px for rounder, more natural-looking edge turns. Raise edge zIndex from 0 to 3 so edges render above subnet containers instead of being partially hidden behind container borders.

https://claude.ai/code/session_01BrehwLocNceLbt4vFRUuCc