### PR TITLE
Increase edge borderRadius to 100 for flowing curves

### DIFF
--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -535,7 +535,7 @@ export function createEdges(data: TopologyResponse): Edge[] {
           animated: true,
           style: { stroke: "#94a3b8", strokeWidth: 2 },
           zIndex: 3,
-          pathOptions: { offset: 20, borderRadius: 20 },
+          pathOptions: { offset: 20, borderRadius: 100 },
         });
       }
     }
@@ -563,7 +563,7 @@ export function createEdges(data: TopologyResponse): Edge[] {
               strokeDasharray: "5,5",
             },
             zIndex: 3,
-            pathOptions: { offset: 25, borderRadius: 20 },
+            pathOptions: { offset: 25, borderRadius: 100 },
           });
         }
       }


### PR DESCRIPTION
Set borderRadius to 100px on smoothstep edges so corners become large arcs instead of near-right-angle turns. React Flow clamps the radius to half the shortest adjacent segment, so this effectively maximizes rounding on every corner for the most natural-looking paths.

https://claude.ai/code/session_01BrehwLocNceLbt4vFRUuCc