### PR TITLE
Fix undefined variable warnings in frontend Dockerfile LABEL

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,6 +28,11 @@ RUN npm run build
 # Production stage - serve with nginx
 FROM nginx:alpine
 
+# Re-declare build args (ARGs don't persist across stages)
+ARG APP_VERSION=0.0.0-unknown
+ARG BUILD_SHA=unknown
+ARG BUILD_DATE=unknown
+
 LABEL version="${APP_VERSION}" \
       build.sha="${BUILD_SHA}" \
       build.date="${BUILD_DATE}"


### PR DESCRIPTION
The ARG declarations for APP_VERSION, BUILD_SHA, and BUILD_DATE were only in the builder stage. In multi-stage Docker builds, ARGs don't persist across FROM boundaries, so the LABEL instruction in the nginx stage was referencing undefined variables. Re-declare the ARGs in the production stage.

https://claude.ai/code/session_018ncFGFZ9AkumwKBMU6nDYL