### PR TITLE
Switch edges from smoothstep to bezier for smooth flowing curves

### DIFF
--- a/frontend/src/components/topology/TopologyCanvas.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.tsx
@@ -89,7 +89,7 @@ export function TopologyCanvas({ data, onNodeClick }: TopologyCanvasProps) {
         minZoom={0.1}
         maxZoom={2}
         defaultEdgeOptions={{
-          type: "smoothstep",
+          type: "default",
           animated: false,
         }}
         proOptions={{ hideAttribution: true }}

--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -531,11 +531,10 @@ export function createEdges(data: TopologyResponse): Edge[] {
           id: `edge-igw-${vpc.internet_gateway.id}-subnet-${subnet.id}`,
           source: `igw-${vpc.internet_gateway.id}`,
           target: `subnet-${subnet.id}`,
-          type: "smoothstep",
+          type: "default",
           animated: true,
           style: { stroke: "#94a3b8", strokeWidth: 2 },
-          zIndex: 3,
-          pathOptions: { offset: 20, borderRadius: 100 },
+          zIndex: 0,
         });
       }
     }
@@ -555,15 +554,14 @@ export function createEdges(data: TopologyResponse): Edge[] {
             id: `edge-nat-${publicSubnet.nat_gateway.id}-subnet-${privateSubnet.id}`,
             source: `nat-${publicSubnet.nat_gateway.id}`,
             target: `subnet-${privateSubnet.id}`,
-            type: "smoothstep",
+            type: "default",
             animated: true,
             style: {
               stroke: "#a78bfa",
               strokeWidth: 2,
               strokeDasharray: "5,5",
             },
-            zIndex: 3,
-            pathOptions: { offset: 25, borderRadius: 100 },
+            zIndex: 0,
           });
         }
       }


### PR DESCRIPTION
Replace smoothstep edge type with default (bezier) for smooth S-curves instead of orthogonal step-paths with corners. This matches the desired flowing edge style. Lower edge zIndex to 0 (below subnets at 1) so edges are hidden where they cross container borders but visible in the gaps between rows. Remove smoothstep-specific pathOptions (offset, borderRadius) as bezier uses curvature-based routing instead.

https://claude.ai/code/session_01BrehwLocNceLbt4vFRUuCc