### PR TITLE
Fix prod login by enabling ALB sticky sessions for SQLite backend

### DIFF
--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -172,6 +172,10 @@ module "alb" {
   frontend_container_port    = var.frontend_container_port
   frontend_health_check_path = var.frontend_health_check_path
 
+  # Sticky sessions required: backend uses SQLite (local file DB) so all
+  # requests from a client must route to the same task to preserve sessions.
+  enable_stickiness = true
+
   enable_deletion_protection = true # Protect production ALB
 }
 

--- a/infrastructure/modules/alb/main.tf
+++ b/infrastructure/modules/alb/main.tf
@@ -342,6 +342,15 @@ resource "aws_lb_target_group" "main" {
     matcher             = "200"
   }
 
+  dynamic "stickiness" {
+    for_each = var.enable_stickiness ? [1] : []
+    content {
+      type            = "lb_cookie"
+      cookie_duration = var.stickiness_duration
+      enabled         = true
+    }
+  }
+
   tags = merge(var.tags, {
     Name = "${var.project_name}-${var.environment}-tg"
   })

--- a/infrastructure/modules/alb/variables.tf
+++ b/infrastructure/modules/alb/variables.tf
@@ -107,6 +107,18 @@ variable "access_logs_prefix" {
 # Frontend Configuration (Optional)
 # -----------------------------------------------------------------------------
 
+variable "enable_stickiness" {
+  description = "Enable sticky sessions on backend target group (required when using SQLite with multiple backend tasks)"
+  type        = bool
+  default     = false
+}
+
+variable "stickiness_duration" {
+  description = "Duration (in seconds) for sticky session cookies"
+  type        = number
+  default     = 86400
+}
+
 variable "frontend_container_port" {
   description = "Port the frontend container listens on (set > 0 to enable frontend routing)"
   type        = number


### PR DESCRIPTION
Production backend runs multiple ECS tasks (desired_count=2) but uses SQLite (file-based, per-task). Login succeeds on one task but the next request may route to a different task that has no record of the session, causing "invalid token" errors. Enable load-balancer cookie stickiness on the backend target group so all requests from a client route to the same task.

https://claude.ai/code/session_01PUMia97FsFB1yMTsv8NdbV