### PR TITLE
Fix CyberArk auth URL and implement settings API endpoints

### DIFF
--- a/backend/app/collectors/cyberark_base.py
+++ b/backend/app/collectors/cyberark_base.py
@@ -38,12 +38,14 @@ class CyberArkBaseCollector(ABC):
 
     async def _authenticate(self) -> str:
         """Obtain OAuth2 token from CyberArk Identity."""
-        if self._token and self._token_expiry and datetime.now(
-            timezone.utc
-        ) < self._token_expiry:
+        if (
+            self._token
+            and self._token_expiry
+            and datetime.now(timezone.utc) < self._token_expiry
+        ):
             return self._token
 
-        token_url = f"{self.identity_url}/oauth2/token/{self.client_id}"
+        token_url = f"{self.identity_url}/oauth2/platformtoken"
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 token_url,


### PR DESCRIPTION
- Fix OAuth2 token URL from /oauth2/token/{client_id} to /oauth2/platformtoken to match the correct CyberArk Identity platform token endpoint
- Implement GET /api/settings/cyberark to retrieve CyberArk settings
- Implement PUT /api/settings/cyberark to save/update CyberArk settings
- Implement POST /api/settings/cyberark/test to test connection by authenticating against the identity tenant with client credentials

https://claude.ai/code/session_01STGvYyvUaYbg5WcGoigb6r