### PR TITLE
Add CyberArk sync status panel to settings UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -585,6 +585,7 @@ import type {
   CyberArkSettingsUpdate,
   CyberArkConnectionTestRequest,
   CyberArkConnectionTestResponse,
+  CyberArkSyncStatus,
 } from "@/types";
 
 export async function getCyberArkSafes(
@@ -700,6 +701,11 @@ export async function testCyberArkConnection(
   data: CyberArkConnectionTestRequest,
 ): Promise<CyberArkConnectionTestResponse> {
   const response = await api.post("/settings/cyberark/test", data);
+  return response.data;
+}
+
+export async function getCyberArkSyncStatus(): Promise<CyberArkSyncStatus> {
+  const response = await api.get("/settings/cyberark/status");
   return response.data;
 }
 

--- a/frontend/src/types/cyberark.ts
+++ b/frontend/src/types/cyberark.ts
@@ -227,6 +227,32 @@ export interface CyberArkConnectionTestResponse {
   details?: Record<string, unknown>;
 }
 
+export interface CyberArkSyncStatus {
+  config: {
+    source: string;
+    enabled: boolean;
+    all_fields_set: boolean;
+    db_settings_exists: boolean;
+    db_enabled: boolean | null;
+    db_base_url_set: boolean;
+    db_identity_url_set: boolean;
+    db_client_id_set: boolean;
+    db_client_secret_set: boolean;
+  };
+  database_counts: {
+    roles_total: number;
+    roles_active: number;
+    safes: number;
+    accounts: number;
+    sia_policies: number;
+  };
+  last_sync: {
+    synced_at: string | null;
+    status: string | null;
+    resource_count: number | null;
+  };
+}
+
 // =============================================================================
 // CyberArk Drift Types
 // =============================================================================


### PR DESCRIPTION
The /api/settings/cyberark/status endpoint requires Bearer auth, so hitting it directly in the browser returns 401. This adds the diagnostic information directly to the CyberArk settings page so admins can see it in the UI without needing curl or Swagger.

Changes:
- Add CyberArkSyncStatus type and getCyberArkSyncStatus API call
- Add SyncStatusPanel component to CyberArkSettings showing:
  - Config source (database/environment/none) and field completeness
  - Contextual warnings: not enabled, missing fields, sync ran but collected 0 resources
  - Database row counts for roles, safes, accounts, SIA policies
  - Last sync timestamp, status, and resource count
  - Refresh status button for checking after a data refresh
- Auto-refresh status after saving settings

https://claude.ai/code/session_01STGvYyvUaYbg5WcGoigb6r