### PR TITLE
Add detailed token and request logging for CyberArk API debugging

### DIFF
--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -859,6 +859,7 @@ async def test_cyberark_connection(
             message="Successfully authenticated with CyberArk Identity",
             details={
                 "token_type": data.get("token_type", ""),
+                "scope": data.get("scope", ""),
                 "expires_in": data.get("expires_in", 0),
             },
         )


### PR DESCRIPTION
Log the token_type, scope, and token prefix from the platformtoken response so we can verify the token format. Log the outgoing Authorization header (masked) on every API call so we can confirm the token is actually being sent. On error responses, log the response headers alongside the body to surface WWW-Authenticate hints. Also return scope in the test connection response details.

https://claude.ai/code/session_01STGvYyvUaYbg5WcGoigb6r