### PR TITLE
Fix access mapping: broken role join and empty graph without targets

### DIFF
--- a/backend/app/api/routes/access_mapping.py
+++ b/backend/app/api/routes/access_mapping.py
@@ -45,9 +45,10 @@ async def get_access_mapping(
             for p in t.access_paths
             if p.access_type == "jit"
         )
+        has_data = bool(user_mapping.targets or user_mapping.access_paths)
         return AccessMappingResponse(
-            users=[user_mapping] if user_mapping.targets else [],
-            total_users=1 if user_mapping.targets else 0,
+            users=[user_mapping] if has_data else [],
+            total_users=1 if has_data else 0,
             total_targets=len(user_mapping.targets),
             total_standing_paths=standing,
             total_jit_paths=jit,

--- a/backend/app/schemas/cyberark.py
+++ b/backend/app/schemas/cyberark.py
@@ -199,6 +199,7 @@ class UserAccessMapping(BaseSchema):
 
     user_name: str
     targets: List[TargetAccessInfo] = []
+    access_paths: List[AccessPath] = []  # Relationship-only paths (no target)
 
 
 class AccessMappingResponse(BaseSchema):

--- a/frontend/src/pages/AccessMappingPage.tsx
+++ b/frontend/src/pages/AccessMappingPage.tsx
@@ -85,8 +85,8 @@ export function AccessMappingPage() {
           </h3>
           <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
             Configure CyberArk integration in Settings and refresh data to see
-            user-to-target access paths. Make sure CyberArk safes, roles, and
-            SIA policies are synced.
+            user access mappings. Make sure CyberArk safes, roles, and accounts
+            are synced.
           </p>
         </div>
         <button

--- a/frontend/src/types/cyberark.ts
+++ b/frontend/src/types/cyberark.ts
@@ -167,6 +167,7 @@ export interface TargetAccessInfo {
 export interface UserAccessMapping {
   user_name: string;
   targets: TargetAccessInfo[];
+  access_paths?: AccessPath[];
 }
 
 export interface AccessMappingResponse {


### PR DESCRIPTION
Two root causes prevented the access map from building:

1. role_id vs member_name join mismatch: _get_user_roles returned SCIM UUIDs (role_id) but safe members store display names (member_name). Fixed by joining through CyberArkRole to get role_name. Also match safe member_type "group" in addition to "role".

2. Graph required matched AWS targets: paths were only created when an account address matched an EC2/RDS instance. Now the service returns relationship-only paths (user→role, user→safe, user→role→safe→account) via a new access_paths field on UserAccessMapping, so the visualization renders even without target matches.

https://claude.ai/code/session_01STGvYyvUaYbg5WcGoigb6r