### PR TITLE
Rewrite SIA collector to match actual UAP API response format

### DIFF
--- a/backend/app/models/cyberark.py
+++ b/backend/app/models/cyberark.py
@@ -186,9 +186,7 @@ class CyberArkRoleMember(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     role_id: Mapped[str] = mapped_column(String(255), nullable=False)
     member_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    member_type: Mapped[str] = mapped_column(
-        String(20), nullable=False
-    )  # user, group
+    member_type: Mapped[str] = mapped_column(String(20), nullable=False)  # user, group
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
@@ -215,8 +213,8 @@ class CyberArkSIAPolicy(Base):
     policy_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     policy_name: Mapped[str] = mapped_column(String(255), nullable=False)
     policy_type: Mapped[str] = mapped_column(
-        String(20), nullable=False
-    )  # vm, database
+        String(50), nullable=False
+    )  # vm, database, cloud_console
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default="active"


### PR DESCRIPTION
- Remove filter parameter; fetch all policies from /access-policies
- Parse nested metadata object: metadata.policyId, metadata.name, metadata.status.status, metadata.policyEntitlement.targetCategory
- Derive policy_type from targetCategory (VM, DB, Cloud Console)
- Handle principals array with type field (USER, GROUP, ROLE)
- Widen policy_type column to String(50) for cloud_console type
- Target criteria left empty for now; individual policy detail fetch via /policies/{policyId} can be added later

https://claude.ai/code/session_01STGvYyvUaYbg5WcGoigb6r