### PR TITLE
Add collapsible VPC and subnet nodes to topology visualization

### DIFF
--- a/frontend/src/components/topology/TopologyCanvas.test.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.test.tsx
@@ -45,10 +45,14 @@ vi.mock("reactflow", () => ({
   ),
   Background: () => <div data-testid="react-flow-background" />,
   Controls: () => <div data-testid="react-flow-controls" />,
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   useNodesState: (initialNodes: MockNode[]) => [initialNodes, vi.fn(), vi.fn()],
   useEdgesState: (
     initialEdges: { id: string; source: string; target: string }[],
   ) => [initialEdges, vi.fn(), vi.fn()],
+  useReactFlow: () => ({ fitView: vi.fn() }),
   BackgroundVariant: { Dots: "dots" },
 }));
 
@@ -156,8 +160,7 @@ describe("TopologyCanvas", () => {
 
   it("renders within a container div", () => {
     const { container } = render(<TopologyCanvas data={mockTopologyData} />);
-    const wrapperDiv = container.firstChild as HTMLElement;
-    expect(wrapperDiv.className).toContain("w-full");
-    expect(wrapperDiv.className).toContain("h-full");
+    const wrapperDiv = container.querySelector(".w-full.h-full");
+    expect(wrapperDiv).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/topology/TopologyCanvas.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
   useNodesState,
   useEdgesState,
+  useReactFlow,
+  ReactFlowProvider,
   BackgroundVariant,
   type NodeTypes,
   type Node,
@@ -42,25 +44,104 @@ interface TopologyCanvasProps {
   ) => void;
 }
 
-export function TopologyCanvas({ data, onNodeClick }: TopologyCanvasProps) {
-  // Calculate layout from data
+function TopologyCanvasInner({ data, onNodeClick }: TopologyCanvasProps) {
+  const reactFlow = useReactFlow();
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const prevCollapsedRef = useRef<Set<string>>(collapsedNodes);
+
+  // Stable toggle factory - creates a toggle function for a given node ID
+  const createToggleCallback = useCallback(
+    (nodeId: string) => () => {
+      setCollapsedNodes((prev) => {
+        const next = new Set(prev);
+        if (next.has(nodeId)) {
+          next.delete(nodeId);
+        } else {
+          next.add(nodeId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Collapse all VPCs and subnets
+  const collapseAll = useCallback(() => {
+    const allIds = new Set<string>();
+    for (const vpc of data.vpcs) {
+      allIds.add(`vpc-${vpc.id}`);
+      for (const subnet of vpc.subnets) {
+        allIds.add(`subnet-${subnet.id}`);
+      }
+    }
+    setCollapsedNodes(allIds);
+  }, [data]);
+
+  // Expand all
+  const expandAll = useCallback(() => {
+    setCollapsedNodes(new Set());
+  }, []);
+
+  // Prune collapsed IDs that no longer exist in data
+  useEffect(() => {
+    setCollapsedNodes((prev) => {
+      const validIds = new Set<string>();
+      for (const vpc of data.vpcs) {
+        validIds.add(`vpc-${vpc.id}`);
+        for (const subnet of vpc.subnets) {
+          validIds.add(`subnet-${subnet.id}`);
+        }
+      }
+      const pruned = new Set([...prev].filter((id) => validIds.has(id)));
+      return pruned.size === prev.size ? prev : pruned;
+    });
+  }, [data]);
+
+  // Calculate layout from data + collapsed state
   const { initialNodes, initialEdges } = useMemo(() => {
-    const layout = calculateTopologyLayout(data);
-    const edges = createEdges(data);
+    const layout = calculateTopologyLayout(data, collapsedNodes);
+    const edges = createEdges(data, collapsedNodes);
+
+    // Inject onToggleCollapse callbacks into VPC and subnet nodes
+    const nodesWithCallbacks = layout.nodes.map((node) => {
+      if (node.type === "vpc" || node.type === "subnet") {
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            onToggleCollapse: createToggleCallback(node.id),
+          },
+        };
+      }
+      return node;
+    });
+
     return {
-      initialNodes: layout.nodes,
+      initialNodes: nodesWithCallbacks,
       initialEdges: [...layout.edges, ...edges],
     };
-  }, [data]);
+  }, [data, collapsedNodes, createToggleCallback]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  // Sync nodes/edges when data changes (e.g. after filtering)
+  // Sync nodes/edges when data or collapsed state changes
   useEffect(() => {
     setNodes(initialNodes);
     setEdges(initialEdges);
   }, [initialNodes, initialEdges, setNodes, setEdges]);
+
+  // Smooth viewport transition after collapse/expand
+  useEffect(() => {
+    if (prevCollapsedRef.current !== collapsedNodes) {
+      prevCollapsedRef.current = collapsedNodes;
+      // Small delay to let React Flow process the node changes first
+      const timer = setTimeout(() => {
+        reactFlow.fitView({ duration: 300, padding: 0.2 });
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [collapsedNodes, reactFlow]);
 
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node<TopologyNodeData>) => {
@@ -70,6 +151,8 @@ export function TopologyCanvas({ data, onNodeClick }: TopologyCanvasProps) {
     },
     [onNodeClick],
   );
+
+  const hasNodes = data.vpcs.length > 0;
 
   return (
     <div className="w-full h-full">
@@ -108,6 +191,32 @@ export function TopologyCanvas({ data, onNodeClick }: TopologyCanvasProps) {
           className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg [&>button]:border-gray-200 [&>button]:dark:border-gray-700"
         />
       </ReactFlow>
+
+      {/* Collapse/Expand All controls */}
+      {hasNodes && (
+        <div className="absolute bottom-4 left-4 z-10 flex gap-2">
+          <button
+            onClick={collapseAll}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
+          >
+            Collapse All
+          </button>
+          <button
+            onClick={expandAll}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
+          >
+            Expand All
+          </button>
+        </div>
+      )}
     </div>
+  );
+}
+
+export function TopologyCanvas(props: TopologyCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <TopologyCanvasInner {...props} />
+    </ReactFlowProvider>
   );
 }

--- a/frontend/src/components/topology/nodes/SubnetNode.tsx
+++ b/frontend/src/components/topology/nodes/SubnetNode.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position, NodeResizer } from "reactflow";
-import { Boxes } from "lucide-react";
+import { Boxes, ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SubnetNodeData } from "@/types/topology";
 
@@ -33,7 +33,7 @@ function SubnetNodeComponent({ data, selected }: NodeProps<SubnetNodeData>) {
   return (
     <div
       className={cn(
-        "w-full h-full rounded-lg border-2 p-3",
+        "w-full h-full rounded-lg border-2 p-3 transition-all duration-300 ease-in-out",
         subnetTypeStyles[data.subnetType],
       )}
     >
@@ -76,7 +76,49 @@ function SubnetNodeComponent({ data, selected }: NodeProps<SubnetNodeData>) {
             {data.cidrBlock} | {data.availabilityZone}
           </div>
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            title={data.collapsed ? "Expand subnet" : "Collapse subnet"}
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronDown className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
+
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="flex flex-wrap gap-1">
+          {data.childSummary.ec2Count > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300">
+              {data.childSummary.ec2Count} EC2
+            </span>
+          )}
+          {data.childSummary.rdsCount > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+              {data.childSummary.rdsCount} RDS
+            </span>
+          )}
+          {data.childSummary.ecsCount > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300">
+              {data.childSummary.ecsCount} ECS
+            </span>
+          )}
+          {data.childSummary.natCount > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300">
+              {data.childSummary.natCount} NAT
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Children will be rendered inside by React Flow */}
 

--- a/frontend/src/components/topology/nodes/VPCNode.tsx
+++ b/frontend/src/components/topology/nodes/VPCNode.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position, NodeResizer } from "reactflow";
-import { Network } from "lucide-react";
+import { Network, ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { VPCNodeData } from "@/types/topology";
 
@@ -16,7 +16,7 @@ function VPCNodeComponent({ data, selected }: NodeProps<VPCNodeData>) {
   return (
     <div
       className={cn(
-        "w-full h-full rounded-lg border-2 border-dashed p-4",
+        "w-full h-full rounded-lg border-2 border-dashed p-4 transition-all duration-300 ease-in-out",
         statusColors[data.displayStatus],
       )}
     >
@@ -52,7 +52,60 @@ function VPCNodeComponent({ data, selected }: NodeProps<VPCNodeData>) {
             <span className="font-mono">{data.vpcId}</span>
           </div>
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            title={data.collapsed ? "Expand VPC" : "Collapse VPC"}
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
+
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="flex flex-wrap gap-1.5">
+          {data.childSummary.subnetCount > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+              {data.childSummary.subnetCount} subnet
+              {data.childSummary.subnetCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {data.childSummary.ec2Count > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300">
+              {data.childSummary.ec2Count} EC2
+            </span>
+          )}
+          {data.childSummary.rdsCount > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+              {data.childSummary.rdsCount} RDS
+            </span>
+          )}
+          {data.childSummary.ecsCount > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300">
+              {data.childSummary.ecsCount} ECS
+            </span>
+          )}
+          {data.childSummary.natCount > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300">
+              {data.childSummary.natCount} NAT
+            </span>
+          )}
+          {data.childSummary.igwCount > 0 && (
+            <span className="px-2 py-0.5 text-xs rounded-full bg-cyan-100 dark:bg-cyan-900/40 text-cyan-700 dark:text-cyan-300">
+              {data.childSummary.igwCount} IGW
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Children will be rendered inside by React Flow */}
 

--- a/frontend/src/components/topology/utils/layoutCalculator.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.ts
@@ -6,6 +6,10 @@
  * - Layer 1: VPC (z-index 0)
  * - Layer 2: Subnet (z-index 1)
  * - Layer 3: Resources - EC2, RDS, Gateways (z-index 2)
+ *
+ * Supports collapsible VPC and Subnet containers. When collapsed,
+ * child nodes are marked hidden and the parent is resized to show
+ * only its header and a summary badge.
  */
 
 import type { Node, Edge } from "reactflow";
@@ -64,6 +68,11 @@ const config = {
     vpcGap: 50,
   },
   resourcesPerRow: 2,
+  // Collapsed dimensions
+  collapsedSubnetHeight: 60,
+  collapsedSubnetWidth: 280,
+  collapsedVpcHeight: 80,
+  collapsedVpcMinWidth: 350,
 };
 
 interface LayoutResult {
@@ -77,9 +86,57 @@ interface SubnetDimensions {
 }
 
 /**
+ * Count resources across all subnets in a VPC
+ */
+function countVPCResources(vpc: TopologyVPC) {
+  let ec2Count = 0;
+  let rdsCount = 0;
+  let ecsCount = 0;
+  let natCount = 0;
+
+  for (const subnet of vpc.subnets) {
+    ec2Count += subnet.ec2_instances.length;
+    rdsCount += subnet.rds_instances.length;
+    ecsCount += subnet.ecs_containers?.length || 0;
+    if (subnet.nat_gateway) natCount++;
+  }
+
+  return {
+    subnetCount: vpc.subnets.length,
+    ec2Count,
+    rdsCount,
+    ecsCount,
+    natCount,
+    igwCount: vpc.internet_gateway ? 1 : 0,
+  };
+}
+
+/**
+ * Count resources within a subnet
+ */
+function countSubnetResources(subnet: TopologySubnet) {
+  return {
+    ec2Count: subnet.ec2_instances.length,
+    rdsCount: subnet.rds_instances.length,
+    ecsCount: subnet.ecs_containers?.length || 0,
+    natCount: subnet.nat_gateway ? 1 : 0,
+  };
+}
+
+/**
  * Calculate the required dimensions for a subnet based on its resources
  */
-function calculateSubnetDimensions(subnet: TopologySubnet): SubnetDimensions {
+function calculateSubnetDimensions(
+  subnet: TopologySubnet,
+  collapsed: boolean,
+): SubnetDimensions {
+  if (collapsed) {
+    return {
+      width: config.collapsedSubnetWidth,
+      height: config.collapsedSubnetHeight,
+    };
+  }
+
   const resourceCount =
     subnet.ec2_instances.length +
     subnet.rds_instances.length +
@@ -113,7 +170,10 @@ function calculateSubnetDimensions(subnet: TopologySubnet): SubnetDimensions {
 /**
  * Calculate the layout for a row of subnets
  */
-function calculateSubnetRowDimensions(subnets: TopologySubnet[]): {
+function calculateSubnetRowDimensions(
+  subnets: TopologySubnet[],
+  collapsedNodeIds: Set<string>,
+): {
   width: number;
   height: number;
   subnetWidths: number[];
@@ -127,7 +187,8 @@ function calculateSubnetRowDimensions(subnets: TopologySubnet[]): {
   const subnetWidths: number[] = [];
 
   for (const subnet of subnets) {
-    const dims = calculateSubnetDimensions(subnet);
+    const isCollapsed = collapsedNodeIds.has(`subnet-${subnet.id}`);
+    const dims = calculateSubnetDimensions(subnet, isCollapsed);
     subnetWidths.push(dims.width);
     totalWidth += dims.width;
     maxHeight = Math.max(maxHeight, dims.height);
@@ -138,14 +199,18 @@ function calculateSubnetRowDimensions(subnets: TopologySubnet[]): {
   return { width: totalWidth, height: maxHeight, subnetWidths };
 }
 
-export function calculateTopologyLayout(data: TopologyResponse): LayoutResult {
+export function calculateTopologyLayout(
+  data: TopologyResponse,
+  collapsedNodeIds?: Set<string>,
+): LayoutResult {
   const nodes: Node<TopologyNodeData>[] = [];
   const edges: Edge[] = [];
+  const collapsed = collapsedNodeIds ?? new Set<string>();
 
   let vpcX = 0;
 
   for (const vpc of data.vpcs) {
-    const vpcLayout = layoutVPC(vpc, vpcX);
+    const vpcLayout = layoutVPC(vpc, vpcX, collapsed);
     nodes.push(...vpcLayout.nodes);
     edges.push(...vpcLayout.edges);
 
@@ -158,23 +223,125 @@ export function calculateTopologyLayout(data: TopologyResponse): LayoutResult {
 function layoutVPC(
   vpc: TopologyVPC,
   startX: number,
+  collapsedNodeIds: Set<string>,
 ): LayoutResult & { width: number; height: number } {
   const nodes: Node<TopologyNodeData>[] = [];
   const edges: Edge[] = [];
 
   const vpcNodeId = `vpc-${vpc.id}`;
+  const vpcCollapsed = collapsedNodeIds.has(vpcNodeId);
+  const childSummary = countVPCResources(vpc);
 
-  // Separate subnets by type
+  if (vpcCollapsed) {
+    // Collapsed VPC: only header + summary badge
+    const vpcWidth = config.collapsedVpcMinWidth;
+    const vpcHeight = config.collapsedVpcHeight;
+
+    nodes.push({
+      id: vpcNodeId,
+      type: "vpc",
+      position: { x: startX, y: 0 },
+      zIndex: Z_INDEX.VPC,
+      data: {
+        type: "vpc",
+        label: vpc.name || "VPC",
+        displayStatus: vpc.display_status,
+        tfManaged: vpc.tf_managed,
+        tfResourceAddress: vpc.tf_resource_address || undefined,
+        vpcId: vpc.id,
+        cidrBlock: vpc.cidr_block,
+        minWidth: vpcWidth,
+        minHeight: vpcHeight,
+        collapsed: true,
+        childSummary,
+      } as VPCNodeData,
+      style: {
+        width: vpcWidth,
+        height: vpcHeight,
+      },
+    });
+
+    // Emit hidden children so they exist in the DOM for transitions
+    if (vpc.internet_gateway) {
+      nodes.push({
+        id: `igw-${vpc.internet_gateway.id}`,
+        type: "internet-gateway",
+        position: { x: 0, y: 0 },
+        parentNode: vpcNodeId,
+        extent: "parent",
+        zIndex: Z_INDEX.GATEWAY,
+        hidden: true,
+        data: {
+          type: "internet-gateway",
+          label: vpc.internet_gateway.name || "Internet Gateway",
+          displayStatus: vpc.internet_gateway.display_status,
+          tfManaged: vpc.internet_gateway.tf_managed,
+          tfResourceAddress:
+            vpc.internet_gateway.tf_resource_address || undefined,
+          igwId: vpc.internet_gateway.id,
+        } as InternetGatewayNodeData,
+      });
+    }
+
+    // Emit hidden subnets and their resources
+    for (const subnet of vpc.subnets) {
+      const subnetNodeId = `subnet-${subnet.id}`;
+      nodes.push({
+        id: subnetNodeId,
+        type: "subnet",
+        position: { x: 0, y: 0 },
+        parentNode: vpcNodeId,
+        extent: "parent",
+        zIndex: Z_INDEX.SUBNET,
+        hidden: true,
+        data: {
+          type: "subnet",
+          label: subnet.name || "Subnet",
+          displayStatus: subnet.display_status,
+          tfManaged: subnet.tf_managed,
+          subnetId: subnet.id,
+          cidrBlock: subnet.cidr_block,
+          subnetType: subnet.subnet_type,
+          availabilityZone: subnet.availability_zone,
+        } as SubnetNodeData,
+        style: { width: 0, height: 0 },
+      });
+
+      // Hidden resources within hidden subnets
+      const resources = collectResources(subnet);
+      for (const resource of resources) {
+        const resourceNode = createResourceNode(
+          resource,
+          subnetNodeId,
+          0,
+          0,
+          true,
+        );
+        if (resourceNode) nodes.push(resourceNode);
+      }
+    }
+
+    return { nodes, edges, width: vpcWidth, height: vpcHeight };
+  }
+
+  // Expanded VPC - normal layout with possible collapsed subnets
   const publicSubnets = vpc.subnets.filter((s) => s.subnet_type === "public");
   const privateSubnets = vpc.subnets.filter((s) => s.subnet_type === "private");
   const unknownSubnets = vpc.subnets.filter((s) => s.subnet_type === "unknown");
 
-  // Calculate dimensions for each row
-  const publicDims = calculateSubnetRowDimensions(publicSubnets);
-  const privateDims = calculateSubnetRowDimensions(privateSubnets);
-  const unknownDims = calculateSubnetRowDimensions(unknownSubnets);
+  const publicDims = calculateSubnetRowDimensions(
+    publicSubnets,
+    collapsedNodeIds,
+  );
+  const privateDims = calculateSubnetRowDimensions(
+    privateSubnets,
+    collapsedNodeIds,
+  );
+  const unknownDims = calculateSubnetRowDimensions(
+    unknownSubnets,
+    collapsedNodeIds,
+  );
 
-  // Calculate total VPC dimensions
   const contentWidth = Math.max(
     publicDims.width,
     privateDims.width,
@@ -183,30 +350,24 @@ function layoutVPC(
   );
   const vpcWidth = contentWidth + config.vpcPadding * 2;
 
-  // Calculate heights
   let contentHeight = 0;
 
-  // IGW height
   if (vpc.internet_gateway) {
     contentHeight += config.nodeHeight.gateway + config.spacing.igwToSubnetGap;
   }
 
-  // Public subnets row
   if (publicSubnets.length > 0) {
     contentHeight += publicDims.height + config.spacing.rowGap;
   }
 
-  // Private subnets row
   if (privateSubnets.length > 0) {
     contentHeight += privateDims.height + config.spacing.rowGap;
   }
 
-  // Unknown subnets row
   if (unknownSubnets.length > 0) {
     contentHeight += unknownDims.height + config.spacing.rowGap;
   }
 
-  // Remove last row gap and add padding
   if (contentHeight > 0) {
     contentHeight -= config.spacing.rowGap;
   }
@@ -214,7 +375,6 @@ function layoutVPC(
   const vpcHeight =
     config.vpcHeaderHeight + contentHeight + config.vpcPadding * 2;
 
-  // Create VPC node (Layer 1 - bottom)
   nodes.push({
     id: vpcNodeId,
     type: "vpc",
@@ -230,6 +390,8 @@ function layoutVPC(
       cidrBlock: vpc.cidr_block,
       minWidth: vpcWidth,
       minHeight: vpcHeight,
+      collapsed: false,
+      childSummary,
     } as VPCNodeData,
     style: {
       width: vpcWidth,
@@ -237,10 +399,8 @@ function layoutVPC(
     },
   });
 
-  // Track Y position relative to VPC content area
   let relativeY = config.vpcHeaderHeight + config.vpcPadding;
 
-  // Internet Gateway at top (child of VPC)
   if (vpc.internet_gateway) {
     nodes.push({
       id: `igw-${vpc.internet_gateway.id}`,
@@ -262,76 +422,180 @@ function layoutVPC(
     relativeY += config.nodeHeight.gateway + config.spacing.igwToSubnetGap;
   }
 
-  // Layout public subnets (children of VPC)
-  if (publicSubnets.length > 0) {
-    const rowStartX = config.vpcPadding + (contentWidth - publicDims.width) / 2;
+  // Layout subnet rows
+  const layoutSubnetRow = (
+    subnets: TopologySubnet[],
+    dims: { width: number; height: number; subnetWidths: number[] },
+  ) => {
+    if (subnets.length === 0) return;
+    const rowStartX = config.vpcPadding + (contentWidth - dims.width) / 2;
     let subnetX = rowStartX;
 
-    publicSubnets.forEach((subnet, idx) => {
-      const subnetDims = calculateSubnetDimensions(subnet);
+    subnets.forEach((subnet, idx) => {
+      const isCollapsed = collapsedNodeIds.has(`subnet-${subnet.id}`);
+      const subnetDims = calculateSubnetDimensions(subnet, isCollapsed);
       const subnetLayout = layoutSubnet(
         subnet,
         subnetX,
         relativeY,
         subnetDims,
-        publicDims.height,
+        dims.height,
         vpcNodeId,
+        collapsedNodeIds,
       );
       nodes.push(...subnetLayout.nodes);
       edges.push(...subnetLayout.edges);
-      subnetX += publicDims.subnetWidths[idx] + config.spacing.horizontal;
+      subnetX += dims.subnetWidths[idx] + config.spacing.horizontal;
     });
 
-    relativeY += publicDims.height + config.spacing.rowGap;
-  }
+    relativeY += dims.height + config.spacing.rowGap;
+  };
 
-  // Layout private subnets (children of VPC)
-  if (privateSubnets.length > 0) {
-    const rowStartX =
-      config.vpcPadding + (contentWidth - privateDims.width) / 2;
-    let subnetX = rowStartX;
-
-    privateSubnets.forEach((subnet, idx) => {
-      const subnetDims = calculateSubnetDimensions(subnet);
-      const subnetLayout = layoutSubnet(
-        subnet,
-        subnetX,
-        relativeY,
-        subnetDims,
-        privateDims.height,
-        vpcNodeId,
-      );
-      nodes.push(...subnetLayout.nodes);
-      edges.push(...subnetLayout.edges);
-      subnetX += privateDims.subnetWidths[idx] + config.spacing.horizontal;
-    });
-
-    relativeY += privateDims.height + config.spacing.rowGap;
-  }
-
-  // Layout unknown subnets (children of VPC)
-  if (unknownSubnets.length > 0) {
-    const rowStartX =
-      config.vpcPadding + (contentWidth - unknownDims.width) / 2;
-    let subnetX = rowStartX;
-
-    unknownSubnets.forEach((subnet, idx) => {
-      const subnetDims = calculateSubnetDimensions(subnet);
-      const subnetLayout = layoutSubnet(
-        subnet,
-        subnetX,
-        relativeY,
-        subnetDims,
-        unknownDims.height,
-        vpcNodeId,
-      );
-      nodes.push(...subnetLayout.nodes);
-      edges.push(...subnetLayout.edges);
-      subnetX += unknownDims.subnetWidths[idx] + config.spacing.horizontal;
-    });
-  }
+  layoutSubnetRow(publicSubnets, publicDims);
+  layoutSubnetRow(privateSubnets, privateDims);
+  layoutSubnetRow(unknownSubnets, unknownDims);
 
   return { nodes, edges, width: vpcWidth, height: vpcHeight };
+}
+
+/**
+ * Collect all resources for a subnet into a uniform list
+ */
+function collectResources(subnet: TopologySubnet): ResourceItem[] {
+  const resources: ResourceItem[] = [];
+
+  if (subnet.nat_gateway) {
+    resources.push({ type: "nat", data: subnet.nat_gateway });
+  }
+
+  subnet.ec2_instances.forEach((ec2) => {
+    resources.push({ type: "ec2", data: ec2 });
+  });
+
+  subnet.rds_instances.forEach((rds) => {
+    resources.push({ type: "rds", data: rds });
+  });
+
+  if (subnet.ecs_containers) {
+    subnet.ecs_containers.forEach((ecs) => {
+      resources.push({ type: "ecs", data: ecs });
+    });
+  }
+
+  return resources;
+}
+
+/**
+ * Create a single resource node
+ */
+function createResourceNode(
+  resource: ResourceItem,
+  subnetNodeId: string,
+  x: number,
+  y: number,
+  hidden: boolean,
+): Node<TopologyNodeData> | null {
+  if (resource.type === "ec2") {
+    const ec2 = resource.data;
+    return {
+      id: `ec2-${ec2.id}`,
+      type: "ec2",
+      position: { x, y },
+      parentNode: subnetNodeId,
+      extent: "parent",
+      zIndex: Z_INDEX.RESOURCE,
+      hidden,
+      data: {
+        type: "ec2",
+        label: ec2.name || ec2.id,
+        displayStatus: ec2.display_status,
+        tfManaged: ec2.tf_managed,
+        tfResourceAddress: ec2.tf_resource_address || undefined,
+        instanceId: ec2.id,
+        instanceType: ec2.instance_type,
+        privateIp: ec2.private_ip || undefined,
+        publicIp: ec2.public_ip || undefined,
+        privateDns: ec2.private_dns || undefined,
+        publicDns: ec2.public_dns || undefined,
+        state: ec2.state,
+      } as EC2NodeData,
+    };
+  } else if (resource.type === "rds") {
+    const rds = resource.data;
+    return {
+      id: `rds-${rds.id}`,
+      type: "rds",
+      position: { x, y },
+      parentNode: subnetNodeId,
+      extent: "parent",
+      zIndex: Z_INDEX.RESOURCE,
+      hidden,
+      data: {
+        type: "rds",
+        label: rds.name || rds.id,
+        displayStatus: rds.display_status,
+        tfManaged: rds.tf_managed,
+        tfResourceAddress: rds.tf_resource_address || undefined,
+        dbIdentifier: rds.id,
+        engine: rds.engine,
+        instanceClass: rds.instance_class,
+        status: rds.status,
+        endpoint: rds.endpoint || undefined,
+        port: rds.port || undefined,
+      } as RDSNodeData,
+    };
+  } else if (resource.type === "ecs") {
+    const ecs = resource.data;
+    return {
+      id: `ecs-${ecs.id}`,
+      type: "ecs-container",
+      position: { x, y },
+      parentNode: subnetNodeId,
+      extent: "parent",
+      zIndex: Z_INDEX.RESOURCE,
+      hidden,
+      data: {
+        type: "ecs-container",
+        label: ecs.name || ecs.id,
+        displayStatus: ecs.display_status,
+        tfManaged: ecs.tf_managed,
+        tfResourceAddress: ecs.tf_resource_address || undefined,
+        taskId: ecs.id,
+        clusterName: ecs.cluster_name,
+        launchType: ecs.launch_type,
+        cpu: ecs.cpu,
+        memory: ecs.memory,
+        status: ecs.status,
+        image: ecs.image || undefined,
+        imageTag: ecs.image_tag || undefined,
+        containerPort: ecs.container_port || undefined,
+        privateIp: ecs.private_ip || undefined,
+        managedBy: ecs.managed_by || "unmanaged",
+      } as ECSContainerNodeData,
+    };
+  } else if (resource.type === "nat") {
+    const nat = resource.data;
+    return {
+      id: `nat-${nat.id}`,
+      type: "nat-gateway",
+      position: { x, y },
+      parentNode: subnetNodeId,
+      extent: "parent",
+      zIndex: Z_INDEX.RESOURCE,
+      hidden,
+      data: {
+        type: "nat-gateway",
+        label: nat.name || "NAT Gateway",
+        displayStatus: nat.display_status,
+        tfManaged: nat.tf_managed,
+        tfResourceAddress: nat.tf_resource_address || undefined,
+        natGatewayId: nat.id,
+        publicIp: nat.primary_public_ip || undefined,
+      } as NATGatewayNodeData,
+    };
+  }
+
+  return null;
 }
 
 function layoutSubnet(
@@ -341,12 +605,15 @@ function layoutSubnet(
   dims: SubnetDimensions,
   rowHeight: number,
   vpcNodeId: string,
+  collapsedNodeIds: Set<string>,
 ): LayoutResult {
   const nodes: Node<TopologyNodeData>[] = [];
   const edges: Edge[] = [];
 
   const subnetNodeId = `subnet-${subnet.id}`;
-  const subnetHeight = rowHeight;
+  const subnetCollapsed = collapsedNodeIds.has(subnetNodeId);
+  const subnetHeight = subnetCollapsed ? dims.height : rowHeight;
+  const childSummary = countSubnetResources(subnet);
 
   // Create subnet node (Layer 2 - child of VPC)
   nodes.push({
@@ -368,6 +635,8 @@ function layoutSubnet(
       availabilityZone: subnet.availability_zone,
       minWidth: dims.width,
       minHeight: subnetHeight,
+      collapsed: subnetCollapsed,
+      childSummary,
     } as SubnetNodeData,
     style: {
       width: dims.width,
@@ -376,33 +645,9 @@ function layoutSubnet(
   });
 
   // Collect all resources
-  const resources: ResourceItem[] = [];
-
-  // Add NAT Gateway first if present
-  if (subnet.nat_gateway) {
-    resources.push({ type: "nat", data: subnet.nat_gateway });
-  }
-
-  // Add EC2 instances
-  subnet.ec2_instances.forEach((ec2) => {
-    resources.push({ type: "ec2", data: ec2 });
-  });
-
-  // Add RDS instances
-  subnet.rds_instances.forEach((rds) => {
-    resources.push({ type: "rds", data: rds });
-  });
-
-  // Add ECS containers
-  if (subnet.ecs_containers) {
-    subnet.ecs_containers.forEach((ecs) => {
-      resources.push({ type: "ecs", data: ecs });
-    });
-  }
+  const resources = collectResources(subnet);
 
   // Layout resources inside subnet (Layer 3 - children of subnet)
-  // Positions are relative to the subnet node
-  // Add subnetPadding to both X and Y for proper spacing from container edges
   const resourceStartX = config.subnetPadding;
   const resourceStartY = config.subnetHeaderHeight + config.subnetPadding;
 
@@ -417,110 +662,30 @@ function layoutSubnet(
       resourceStartY +
       row * (config.nodeHeight.resource + config.spacing.vertical);
 
-    if (resource.type === "ec2") {
-      const ec2 = resource.data;
-      nodes.push({
-        id: `ec2-${ec2.id}`,
-        type: "ec2",
-        position: { x, y },
-        parentNode: subnetNodeId,
-        extent: "parent",
-        zIndex: Z_INDEX.RESOURCE,
-        data: {
-          type: "ec2",
-          label: ec2.name || ec2.id,
-          displayStatus: ec2.display_status,
-          tfManaged: ec2.tf_managed,
-          tfResourceAddress: ec2.tf_resource_address || undefined,
-          instanceId: ec2.id,
-          instanceType: ec2.instance_type,
-          privateIp: ec2.private_ip || undefined,
-          publicIp: ec2.public_ip || undefined,
-          privateDns: ec2.private_dns || undefined,
-          publicDns: ec2.public_dns || undefined,
-          state: ec2.state,
-        } as EC2NodeData,
-      });
-    } else if (resource.type === "rds") {
-      const rds = resource.data;
-      nodes.push({
-        id: `rds-${rds.id}`,
-        type: "rds",
-        position: { x, y },
-        parentNode: subnetNodeId,
-        extent: "parent",
-        zIndex: Z_INDEX.RESOURCE,
-        data: {
-          type: "rds",
-          label: rds.name || rds.id,
-          displayStatus: rds.display_status,
-          tfManaged: rds.tf_managed,
-          tfResourceAddress: rds.tf_resource_address || undefined,
-          dbIdentifier: rds.id,
-          engine: rds.engine,
-          instanceClass: rds.instance_class,
-          status: rds.status,
-          endpoint: rds.endpoint || undefined,
-          port: rds.port || undefined,
-        } as RDSNodeData,
-      });
-    } else if (resource.type === "ecs") {
-      const ecs = resource.data;
-      nodes.push({
-        id: `ecs-${ecs.id}`,
-        type: "ecs-container",
-        position: { x, y },
-        parentNode: subnetNodeId,
-        extent: "parent",
-        zIndex: Z_INDEX.RESOURCE,
-        data: {
-          type: "ecs-container",
-          label: ecs.name || ecs.id,
-          displayStatus: ecs.display_status,
-          tfManaged: ecs.tf_managed,
-          tfResourceAddress: ecs.tf_resource_address || undefined,
-          taskId: ecs.id,
-          clusterName: ecs.cluster_name,
-          launchType: ecs.launch_type,
-          cpu: ecs.cpu,
-          memory: ecs.memory,
-          status: ecs.status,
-          image: ecs.image || undefined,
-          imageTag: ecs.image_tag || undefined,
-          containerPort: ecs.container_port || undefined,
-          privateIp: ecs.private_ip || undefined,
-          managedBy: ecs.managed_by || "unmanaged",
-        } as ECSContainerNodeData,
-      });
-    } else if (resource.type === "nat") {
-      const nat = resource.data;
-      nodes.push({
-        id: `nat-${nat.id}`,
-        type: "nat-gateway",
-        position: { x, y },
-        parentNode: subnetNodeId,
-        extent: "parent",
-        zIndex: Z_INDEX.RESOURCE,
-        data: {
-          type: "nat-gateway",
-          label: nat.name || "NAT Gateway",
-          displayStatus: nat.display_status,
-          tfManaged: nat.tf_managed,
-          tfResourceAddress: nat.tf_resource_address || undefined,
-          natGatewayId: nat.id,
-          publicIp: nat.primary_public_ip || undefined,
-        } as NATGatewayNodeData,
-      });
-    }
+    const resourceNode = createResourceNode(
+      resource,
+      subnetNodeId,
+      x,
+      y,
+      subnetCollapsed,
+    );
+    if (resourceNode) nodes.push(resourceNode);
   });
 
   return { nodes, edges };
 }
 
-export function createEdges(data: TopologyResponse): Edge[] {
+export function createEdges(
+  data: TopologyResponse,
+  collapsedNodeIds?: Set<string>,
+): Edge[] {
   const edges: Edge[] = [];
+  const collapsed = collapsedNodeIds ?? new Set<string>();
 
   for (const vpc of data.vpcs) {
+    // Skip all edges for collapsed VPCs (children are hidden)
+    if (collapsed.has(`vpc-${vpc.id}`)) continue;
+
     // Create edges for IGW -> public subnets
     if (vpc.internet_gateway) {
       const publicSubnets = vpc.subnets.filter(
@@ -548,6 +713,9 @@ export function createEdges(data: TopologyResponse): Edge[] {
     );
 
     for (const publicSubnet of publicSubnetsWithNat) {
+      // Skip NAT edges if the subnet containing the NAT is collapsed (NAT is hidden)
+      if (collapsed.has(`subnet-${publicSubnet.id}`)) continue;
+
       if (publicSubnet.nat_gateway) {
         for (const privateSubnet of privateSubnets) {
           edges.push({

--- a/frontend/src/types/topology.ts
+++ b/frontend/src/types/topology.ts
@@ -148,12 +148,31 @@ interface BaseNodeData {
   tfResourceAddress?: string;
 }
 
+export interface VPCChildSummary {
+  subnetCount: number;
+  ec2Count: number;
+  rdsCount: number;
+  ecsCount: number;
+  natCount: number;
+  igwCount: number;
+}
+
 export interface VPCNodeData extends BaseNodeData {
   type: "vpc";
   vpcId: string;
   cidrBlock: string;
   minWidth?: number;
   minHeight?: number;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  childSummary?: VPCChildSummary;
+}
+
+export interface SubnetChildSummary {
+  ec2Count: number;
+  rdsCount: number;
+  ecsCount: number;
+  natCount: number;
 }
 
 export interface SubnetNodeData extends BaseNodeData {
@@ -164,6 +183,9 @@ export interface SubnetNodeData extends BaseNodeData {
   availabilityZone: string;
   minWidth?: number;
   minHeight?: number;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  childSummary?: SubnetChildSummary;
 }
 
 export interface EC2NodeData extends BaseNodeData {


### PR DESCRIPTION
Users can now click chevron toggles on VPC and subnet containers to collapse/expand their children. Collapsed containers show color-coded summary badges (e.g., "3 EC2", "1 RDS") and resize to a compact form. Includes "Collapse All"/"Expand All" buttons and smooth viewport transitions via fitView after toggle.

https://claude.ai/code/session_01BNae6swLry5RGgYngUF9uk