### PR TITLE
Add collapsible branches to access mapping visualization

### DIFF
--- a/frontend/src/components/access-mapping/AccessMappingCanvas.tsx
+++ b/frontend/src/components/access-mapping/AccessMappingCanvas.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
   useNodesState,
   useEdgesState,
+  useReactFlow,
+  ReactFlowProvider,
   BackgroundVariant,
   type NodeTypes,
 } from "reactflow";
@@ -20,6 +22,14 @@ import {
 } from "./nodes";
 import { calculateAccessMappingLayout } from "./utils/accessMappingLayout";
 import type { AccessMappingResponse } from "@/types";
+
+// Node types that support collapsing (have outgoing edges to downstream nodes)
+const COLLAPSIBLE_TYPES = new Set([
+  "access-user",
+  "access-role",
+  "access-safe",
+  "access-sia-policy",
+]);
 
 // Register custom node types
 const nodeTypes: NodeTypes = {
@@ -40,26 +50,99 @@ interface AccessMappingCanvasProps {
   };
 }
 
-export function AccessMappingCanvas({
-  data,
-  filters,
-}: AccessMappingCanvasProps) {
-  const { initialNodes, initialEdges } = useMemo(() => {
+function AccessMappingCanvasInner({ data, filters }: AccessMappingCanvasProps) {
+  const reactFlow = useReactFlow();
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const prevCollapsedRef = useRef<Set<string>>(collapsedNodes);
+
+  // Stable toggle factory
+  const createToggleCallback = useCallback(
+    (nodeId: string) => () => {
+      setCollapsedNodes((prev) => {
+        const next = new Set(prev);
+        if (next.has(nodeId)) {
+          next.delete(nodeId);
+        } else {
+          next.add(nodeId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Collapse all collapsible nodes
+  const collapseAll = useCallback(() => {
     const layout = calculateAccessMappingLayout(data, filters);
+    const allIds = new Set<string>();
+    for (const node of layout.nodes) {
+      if (COLLAPSIBLE_TYPES.has(node.type || "")) {
+        allIds.add(node.id);
+      }
+    }
+    setCollapsedNodes(allIds);
+  }, [data, filters]);
+
+  // Expand all
+  const expandAll = useCallback(() => {
+    setCollapsedNodes(new Set());
+  }, []);
+
+  // Prune collapsed IDs that no longer exist in data
+  useEffect(() => {
+    const layout = calculateAccessMappingLayout(data, filters);
+    const validIds = new Set(layout.nodes.map((n) => n.id));
+    setCollapsedNodes((prev) => {
+      const pruned = new Set([...prev].filter((id) => validIds.has(id)));
+      return pruned.size === prev.size ? prev : pruned;
+    });
+  }, [data, filters]);
+
+  // Calculate layout with collapsed state
+  const { initialNodes, initialEdges } = useMemo(() => {
+    const layout = calculateAccessMappingLayout(data, filters, collapsedNodes);
+
+    // Inject onToggleCollapse callbacks into collapsible nodes
+    const nodesWithCallbacks = layout.nodes.map((node) => {
+      if (COLLAPSIBLE_TYPES.has(node.type || "")) {
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            onToggleCollapse: createToggleCallback(node.id),
+          },
+        };
+      }
+      return node;
+    });
+
     return {
-      initialNodes: layout.nodes,
+      initialNodes: nodesWithCallbacks,
       initialEdges: layout.edges,
     };
-  }, [data, filters]);
+  }, [data, filters, collapsedNodes, createToggleCallback]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  // Sync nodes/edges when data or filters change
+  // Sync nodes/edges when data, filters, or collapsed state changes
   useEffect(() => {
     setNodes(initialNodes);
     setEdges(initialEdges);
   }, [initialNodes, initialEdges, setNodes, setEdges]);
+
+  // Smooth viewport transition after collapse/expand
+  useEffect(() => {
+    if (prevCollapsedRef.current !== collapsedNodes) {
+      prevCollapsedRef.current = collapsedNodes;
+      const timer = setTimeout(() => {
+        reactFlow.fitView({ duration: 300, padding: 0.3 });
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [collapsedNodes, reactFlow]);
+
+  const hasNodes = data.users.length > 0;
 
   return (
     <div className="w-full h-full">
@@ -97,6 +180,32 @@ export function AccessMappingCanvas({
           className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg [&>button]:border-gray-200 [&>button]:dark:border-gray-700"
         />
       </ReactFlow>
+
+      {/* Collapse/Expand All controls */}
+      {hasNodes && (
+        <div className="absolute bottom-4 left-4 z-10 flex gap-2">
+          <button
+            onClick={collapseAll}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
+          >
+            Collapse All
+          </button>
+          <button
+            onClick={expandAll}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
+          >
+            Expand All
+          </button>
+        </div>
+      )}
     </div>
+  );
+}
+
+export function AccessMappingCanvas(props: AccessMappingCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <AccessMappingCanvasInner {...props} />
+    </ReactFlowProvider>
   );
 }

--- a/frontend/src/components/access-mapping/nodes/RoleNode.tsx
+++ b/frontend/src/components/access-mapping/nodes/RoleNode.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position } from "reactflow";
-import { ShieldCheck } from "lucide-react";
+import { ShieldCheck, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { CollapsibleNodeData } from "@/types";
 
-interface RoleNodeData {
+interface RoleNodeData extends CollapsibleNodeData {
   label: string;
   roleName: string;
 }
@@ -12,7 +13,7 @@ function RoleNodeComponent({ data }: NodeProps<RoleNodeData>) {
   return (
     <div
       className={cn(
-        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm",
+        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm transition-all duration-300 ease-in-out",
         "border-purple-500 bg-white dark:bg-gray-900",
       )}
     >
@@ -27,7 +28,51 @@ function RoleNodeComponent({ data }: NodeProps<RoleNodeData>) {
             {data.roleName || data.label || "Role"}
           </span>
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors shrink-0"
+            title={
+              data.collapsed
+                ? "Expand downstream paths"
+                : "Collapse downstream paths"
+            }
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronLeft className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
+
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {(data.childSummary.targetCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">
+              {data.childSummary.targetCount} target
+              {data.childSummary.targetCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.safeCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+              {data.childSummary.safeCount} safe
+              {data.childSummary.safeCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.policyCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300">
+              {data.childSummary.policyCount} polic
+              {data.childSummary.policyCount !== 1 ? "ies" : "y"}
+            </span>
+          )}
+        </div>
+      )}
 
       <Handle type="source" position={Position.Right} className="opacity-0" />
     </div>

--- a/frontend/src/components/access-mapping/nodes/SIAPolicyNode.tsx
+++ b/frontend/src/components/access-mapping/nodes/SIAPolicyNode.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position } from "reactflow";
-import { Zap } from "lucide-react";
+import { Zap, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { CollapsibleNodeData } from "@/types";
 
-interface SIAPolicyNodeData {
+interface SIAPolicyNodeData extends CollapsibleNodeData {
   label: string;
   policyName: string;
   policyType?: string;
@@ -14,7 +15,7 @@ function SIAPolicyNodeComponent({ data }: NodeProps<SIAPolicyNodeData>) {
   return (
     <div
       className={cn(
-        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm",
+        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm transition-all duration-300 ease-in-out",
         "border-orange-500 bg-white dark:bg-gray-900",
       )}
     >
@@ -28,7 +29,7 @@ function SIAPolicyNodeComponent({ data }: NodeProps<SIAPolicyNodeData>) {
           <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate block">
             {data.policyName || data.label || "Policy"}
           </span>
-          {data.policyType && (
+          {!data.collapsed && data.policyType && (
             <div className="mt-1">
               <span className="px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300 rounded">
                 {data.policyType}
@@ -36,9 +37,41 @@ function SIAPolicyNodeComponent({ data }: NodeProps<SIAPolicyNodeData>) {
             </div>
           )}
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors shrink-0"
+            title={
+              data.collapsed
+                ? "Expand downstream paths"
+                : "Collapse downstream paths"
+            }
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronLeft className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
 
-      {data.tfManaged && (
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {(data.childSummary.targetCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">
+              {data.childSummary.targetCount} target
+              {data.childSummary.targetCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      )}
+
+      {!data.collapsed && data.tfManaged && (
         <div className="mt-1.5 flex justify-end">
           <span className="px-1 py-0.5 text-[10px] font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300 rounded">
             TF

--- a/frontend/src/components/access-mapping/nodes/SafeNode.tsx
+++ b/frontend/src/components/access-mapping/nodes/SafeNode.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position } from "reactflow";
-import { Vault } from "lucide-react";
+import { Vault, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { CollapsibleNodeData } from "@/types";
 
-interface SafeNodeData {
+interface SafeNodeData extends CollapsibleNodeData {
   label: string;
   safeName: string;
   accountCount?: number;
@@ -14,7 +15,7 @@ function SafeNodeComponent({ data }: NodeProps<SafeNodeData>) {
   return (
     <div
       className={cn(
-        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm",
+        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm transition-all duration-300 ease-in-out",
         "border-amber-500 bg-white dark:bg-gray-900",
       )}
     >
@@ -28,16 +29,54 @@ function SafeNodeComponent({ data }: NodeProps<SafeNodeData>) {
           <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate block">
             {data.safeName || data.label || "Safe"}
           </span>
-          {data.accountCount !== undefined && (
+          {!data.collapsed && data.accountCount !== undefined && (
             <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
               {data.accountCount}{" "}
               {data.accountCount === 1 ? "account" : "accounts"}
             </div>
           )}
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors shrink-0"
+            title={
+              data.collapsed
+                ? "Expand downstream paths"
+                : "Collapse downstream paths"
+            }
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronLeft className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
 
-      {data.tfManaged && (
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {(data.childSummary.accountCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+              {data.childSummary.accountCount} account
+              {data.childSummary.accountCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.targetCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">
+              {data.childSummary.targetCount} target
+              {data.childSummary.targetCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      )}
+
+      {!data.collapsed && data.tfManaged && (
         <div className="mt-1.5 flex justify-end">
           <span className="px-1 py-0.5 text-[10px] font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300 rounded">
             TF

--- a/frontend/src/components/access-mapping/nodes/UserNode.tsx
+++ b/frontend/src/components/access-mapping/nodes/UserNode.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
 import { NodeProps, Handle, Position } from "reactflow";
-import { User } from "lucide-react";
+import { User, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { CollapsibleNodeData } from "@/types";
 
-interface UserNodeData {
+interface UserNodeData extends CollapsibleNodeData {
   label: string;
   userName: string;
 }
@@ -12,7 +13,7 @@ function UserNodeComponent({ data }: NodeProps<UserNodeData>) {
   return (
     <div
       className={cn(
-        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm",
+        "w-[280px] rounded-lg border-2 p-2.5 shadow-sm transition-all duration-300 ease-in-out",
         "border-blue-500 bg-white dark:bg-gray-900",
       )}
     >
@@ -27,7 +28,55 @@ function UserNodeComponent({ data }: NodeProps<UserNodeData>) {
             {data.userName || data.label || "User"}
           </span>
         </div>
+        {data.onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              data.onToggleCollapse?.();
+            }}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors shrink-0"
+            title={
+              data.collapsed ? "Expand access paths" : "Collapse access paths"
+            }
+          >
+            {data.collapsed ? (
+              <ChevronRight className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+            ) : (
+              <ChevronLeft className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+            )}
+          </button>
+        )}
       </div>
+
+      {/* Collapsed summary badges */}
+      {data.collapsed && data.childSummary && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {(data.childSummary.targetCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">
+              {data.childSummary.targetCount} target
+              {data.childSummary.targetCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.roleCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300">
+              {data.childSummary.roleCount} role
+              {data.childSummary.roleCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.safeCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+              {data.childSummary.safeCount} safe
+              {data.childSummary.safeCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(data.childSummary.policyCount ?? 0) > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300">
+              {data.childSummary.policyCount} polic
+              {data.childSummary.policyCount !== 1 ? "ies" : "y"}
+            </span>
+          )}
+        </div>
+      )}
 
       <Handle type="source" position={Position.Right} className="opacity-0" />
     </div>

--- a/frontend/src/types/cyberark.ts
+++ b/frontend/src/types/cyberark.ts
@@ -194,6 +194,26 @@ export interface AccessMappingTargetList {
 }
 
 // =============================================================================
+// Access Mapping Node Data (Collapsible)
+// =============================================================================
+
+export interface AccessNodeChildSummary {
+  roleCount?: number;
+  safeCount?: number;
+  policyCount?: number;
+  accountCount?: number;
+  targetCount?: number;
+  standingCount?: number;
+  jitCount?: number;
+}
+
+export interface CollapsibleNodeData {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  childSummary?: AccessNodeChildSummary;
+}
+
+// =============================================================================
 // CyberArk User Types (SCIM)
 // =============================================================================
 


### PR DESCRIPTION
Users can now click chevron toggles on User, Role, Safe, and SIA Policy nodes to collapse their downstream access paths. Collapsed nodes show color-coded summary badges (targets, roles, safes, accounts). Shared nodes remain visible when other paths still reach them via edge-aware reachability computation. Includes "Collapse All"/"Expand All" buttons and smooth viewport transitions.

https://claude.ai/code/session_01BNae6swLry5RGgYngUF9uk