### PR TITLE
Add CyberArk UAP base URL configuration for SIA policy collection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ CYBERARK_ENABLED=false
 # CyberArk Identity tenant URL
 # CYBERARK_IDENTITY_URL=https://your-tenant.id.cyberark.cloud
 
+# CyberArk UAP (Unified Access Portal) base URL for SIA policy collection
+# Discovered automatically via tenant discovery in the Settings UI
+# CYBERARK_UAP_BASE_URL=https://your-tenant.uap.cyberark.cloud/api
+
 # CyberArk API credentials (service account with read permissions)
 # IMPORTANT: Use secrets manager or vault in production
 # CYBERARK_CLIENT_ID=

--- a/backend/app/api/routes/resources.py
+++ b/backend/app/api/routes/resources.py
@@ -1132,7 +1132,7 @@ async def _get_cyberark_config(db: AsyncSession) -> dict | None:
         logger.info("CyberArk: using environment variable settings")
         base_url = settings.cyberark_base_url
         identity_url = settings.cyberark_identity_url
-        uap_base_url = None
+        uap_base_url = settings.cyberark_uap_base_url
         client_id = settings.cyberark_client_id
         client_secret = settings.cyberark_client_secret
     else:
@@ -1248,9 +1248,7 @@ async def _refresh_cyberark(db: AsyncSession) -> int:
                 uap_base_url=uap_base_url, **config
             )
             policies = await sia_collector.collect()
-            logger.info(
-                "CyberArk: collected %d SIA policies from API", len(policies)
-            )
+            logger.info("CyberArk: collected %d SIA policies from API", len(policies))
             policy_count = await _sync_cyberark_sia_policies(db, policies)
             total += policy_count
 

--- a/backend/app/collectors/cyberark_sia.py
+++ b/backend/app/collectors/cyberark_sia.py
@@ -5,7 +5,7 @@ SIA policies live on the UAP (Unified Access Portal) service, not Privilege
 Cloud.  The UAP base URL is discovered from the platform-discovery API
 (``uap.api``) and looks like ``https://<subdomain>.uap.cyberark.cloud/api``.
 
-The list endpoint is ``GET /access-policies`` (no filter).  Each item in the
+The list endpoint is ``GET /policies`` (no filter).  Each item in the
 ``results`` array has a ``metadata`` object and a top-level ``principals``
 array.  The ``metadata.policyEntitlement.targetCategory`` field indicates the
 policy type (``VM``, ``DB``, ``Cloud Console``, etc.).
@@ -62,7 +62,7 @@ class CyberArkSIAPolicyCollector(CyberArkBaseCollector):
 
     async def _fetch_all_policies(self) -> List[Dict[str, Any]]:
         """Fetch all access policies with nextToken pagination."""
-        url = f"{self.uap_base_url}/access-policies"
+        url = f"{self.uap_base_url}/policies"
         all_policies: List[Dict[str, Any]] = []
         params: Dict[str, str] = {}
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -131,6 +131,10 @@ class Settings(BaseSettings):
     cyberark_client_secret: Optional[str] = Field(
         default=None, description="CyberArk API client secret"
     )
+    cyberark_uap_base_url: Optional[str] = Field(
+        default=None,
+        description="CyberArk UAP (Unified Access Portal) base URL for SIA policies",
+    )
 
     # Configurable TF resource type names (idsec provider)
     cyberark_tf_safe_type: str = Field(


### PR DESCRIPTION
## Summary
This PR adds support for configuring the CyberArk UAP (Unified Access Portal) base URL as an environment variable, enabling users to manually specify the UAP endpoint for SIA policy collection instead of relying solely on automatic discovery.

## Key Changes
- **Configuration**: Added `CYBERARK_UAP_BASE_URL` environment variable to `config.py` with optional field definition
- **Environment Setup**: Updated `.env.example` with documentation for the new UAP base URL configuration option
- **API Routes**: Modified `_get_cyberark_config()` to use the configured `cyberark_uap_base_url` setting instead of hardcoding `None`
- **SIA Collector**: Corrected the CyberArk SIA API endpoint from `/access-policies` to `/policies` in both the documentation and implementation
- **Code Cleanup**: Reformatted a multi-line logger statement to a single line for consistency

## Implementation Details
- The `cyberark_uap_base_url` is optional and defaults to `None`, allowing automatic discovery via tenant discovery in the Settings UI when not explicitly configured
- The endpoint correction from `/access-policies` to `/policies` aligns the implementation with the actual CyberArk API specification
- This change maintains backward compatibility while providing flexibility for environments that need explicit UAP URL configuration

https://claude.ai/code/session_014CyJFnndR9Q8mPPyWKUbHJ