### PR TITLE
Add CyberArk API and SCIM settings to Terraform deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,10 +90,21 @@ CYBERARK_ENABLED=false
 # Discovered automatically via tenant discovery in the Settings UI
 # CYBERARK_UAP_BASE_URL=https://your-tenant.uap.cyberark.cloud/api
 
+# CyberArk tenant name (for auto-discovery of URLs)
+# CYBERARK_TENANT_NAME=your-tenant-name
+
 # CyberArk API credentials (service account with read permissions)
 # IMPORTANT: Use secrets manager or vault in production
 # CYBERARK_CLIENT_ID=
 # CYBERARK_CLIENT_SECRET=
+
+# CyberArk SCIM Integration (optional - for Identity user/role collection)
+# Requires CyberArk Identity URL to be configured above
+# CYBERARK_SCIM_ENABLED=false
+# CYBERARK_SCIM_APP_ID=
+# CYBERARK_SCIM_SCOPE=
+# CYBERARK_SCIM_CLIENT_ID=
+# CYBERARK_SCIM_CLIENT_SECRET=
 
 # Terraform resource type overrides for the idsec provider
 # Override these if your idsec provider uses different resource type names

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -766,12 +766,25 @@ async def _get_or_create_cyberark_settings(
         return settings
 
     settings = CyberArkSettings(
+        tenant_name=env_settings.cyberark_tenant_name,
         enabled=env_settings.cyberark_enabled,
         base_url=env_settings.cyberark_base_url,
         identity_url=env_settings.cyberark_identity_url,
+        uap_base_url=env_settings.cyberark_uap_base_url,
         client_id=env_settings.cyberark_client_id,
         client_secret=env_settings.cyberark_client_secret,
+        scim_enabled=env_settings.cyberark_scim_enabled,
+        scim_app_id=env_settings.cyberark_scim_app_id,
+        scim_scope=env_settings.cyberark_scim_scope,
+        scim_client_id=env_settings.cyberark_scim_client_id,
+        scim_client_secret=env_settings.cyberark_scim_client_secret,
     )
+    # Auto-derive scim_oauth2_url if both identity_url and scim_app_id are set
+    if settings.identity_url and settings.scim_app_id:
+        identity_base = settings.identity_url.rstrip("/")
+        settings.scim_oauth2_url = (
+            f"{identity_base}/oauth2/token/{settings.scim_app_id}"
+        )
     db.add(settings)
     await db.commit()
     await db.refresh(settings)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -158,6 +158,28 @@ class Settings(BaseSettings):
         description="Terraform resource type for SIA DB policy",
     )
 
+    # CyberArk tenant name (seeds CyberArkSettings in database on startup)
+    cyberark_tenant_name: Optional[str] = Field(
+        default=None, description="CyberArk tenant name for auto-discovery"
+    )
+
+    # SCIM integration (seeds CyberArkSettings in database on startup)
+    cyberark_scim_enabled: bool = Field(
+        default=False, description="Enable CyberArk SCIM user collection"
+    )
+    cyberark_scim_app_id: Optional[str] = Field(
+        default=None, description="CyberArk Identity SCIM application ID"
+    )
+    cyberark_scim_scope: Optional[str] = Field(
+        default=None, description="OAuth2 scope for SCIM token request"
+    )
+    cyberark_scim_client_id: Optional[str] = Field(
+        default=None, description="SCIM OAuth2 client ID"
+    )
+    cyberark_scim_client_secret: Optional[str] = Field(
+        default=None, description="SCIM OAuth2 client secret"
+    )
+
     @property
     def cors_origins_list(self) -> List[str]:
         """Parse CORS origins string into a list."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,9 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.deps import get_current_user
 from app.api.routes import (
+    access_mapping,
     auth,
+    cyberark,
     ec2,
     ecs,
     eip,
@@ -23,7 +25,6 @@ from app.api.routes import (
     rds,
     resources,
 )
-from app.api.routes import access_mapping, cyberark
 from app.api.routes import settings as settings_routes
 from app.api.routes import subnet, terraform, topology, users, vpc
 from app.config import get_settings
@@ -44,15 +45,17 @@ async def lifespan(app: FastAPI):
     """Application lifespan handler for startup and shutdown events."""
     from app.models.database import async_session_maker
     from app.services.auth import ensure_admin_user
+    from app.services.cyberark_settings import ensure_cyberark_settings
 
     # Startup
     logger.info("Starting AWS Infrastructure Visualizer...")
     await init_db()
     logger.info("Database initialized")
 
-    # Ensure admin user exists if configured
+    # Ensure admin user and CyberArk settings exist if configured
     async with async_session_maker() as session:
         await ensure_admin_user(session)
+        await ensure_cyberark_settings(session)
 
     yield
 

--- a/backend/app/services/cyberark_settings.py
+++ b/backend/app/services/cyberark_settings.py
@@ -1,0 +1,85 @@
+"""
+CyberArk settings startup seeding service.
+
+Seeds CyberArkSettings in the database from environment variables on startup,
+similar to how ensure_admin_user auto-provisions the admin account.
+"""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.models.cyberark import CyberArkSettings
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_cyberark_settings(db: AsyncSession) -> None:
+    """
+    Seed or sync CyberArk settings from environment variables on startup.
+
+    If no CyberArkSettings row exists and CyberArk env vars are configured,
+    creates one seeded from env vars. If a row exists and env vars provide
+    secrets, syncs secrets so Secrets Manager values stay current.
+    """
+    settings = get_settings()
+
+    # Only proceed if at least some CyberArk config is provided
+    if not (settings.cyberark_enabled or settings.cyberark_scim_enabled):
+        logger.debug("No CyberArk env vars configured; skipping settings seed")
+        return
+
+    result = await db.execute(select(CyberArkSettings).limit(1))
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        # Sync secrets from env vars if provided (Secrets Manager may have
+        # rotated values that should override what is in the DB)
+        changed = False
+        if (
+            settings.cyberark_client_secret
+            and settings.cyberark_client_secret != existing.client_secret
+        ):
+            existing.client_secret = settings.cyberark_client_secret
+            changed = True
+        if (
+            settings.cyberark_scim_client_secret
+            and settings.cyberark_scim_client_secret != existing.scim_client_secret
+        ):
+            existing.scim_client_secret = settings.cyberark_scim_client_secret
+            changed = True
+        if changed:
+            await db.commit()
+            logger.info("CyberArk settings secrets synced from environment")
+        else:
+            logger.debug("CyberArk settings already exist; no env sync needed")
+        return
+
+    # No row exists — create one seeded from env vars
+    new_settings = CyberArkSettings(
+        tenant_name=settings.cyberark_tenant_name,
+        enabled=settings.cyberark_enabled,
+        base_url=settings.cyberark_base_url,
+        identity_url=settings.cyberark_identity_url,
+        uap_base_url=settings.cyberark_uap_base_url,
+        client_id=settings.cyberark_client_id,
+        client_secret=settings.cyberark_client_secret,
+        scim_enabled=settings.cyberark_scim_enabled,
+        scim_app_id=settings.cyberark_scim_app_id,
+        scim_scope=settings.cyberark_scim_scope,
+        scim_client_id=settings.cyberark_scim_client_id,
+        scim_client_secret=settings.cyberark_scim_client_secret,
+    )
+
+    # Auto-derive scim_oauth2_url if both identity_url and scim_app_id are set
+    if new_settings.identity_url and new_settings.scim_app_id:
+        identity_base = new_settings.identity_url.rstrip("/")
+        new_settings.scim_oauth2_url = (
+            f"{identity_base}/oauth2/token/{new_settings.scim_app_id}"
+        )
+
+    db.add(new_settings)
+    await db.commit()
+    logger.info("CyberArk settings seeded from environment variables")

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -85,6 +85,20 @@ locals {
     OIDC_ISSUER      = var.oidc_issuer
     OIDC_CLIENT_ID   = var.oidc_client_id
     ADMIN_USERNAME   = var.admin_username
+
+    # CyberArk
+    CYBERARK_ENABLED      = tostring(var.cyberark_enabled)
+    CYBERARK_TENANT_NAME  = var.cyberark_tenant_name
+    CYBERARK_BASE_URL     = var.cyberark_base_url
+    CYBERARK_IDENTITY_URL = var.cyberark_identity_url
+    CYBERARK_CLIENT_ID    = var.cyberark_client_id
+    CYBERARK_UAP_BASE_URL = var.cyberark_uap_base_url
+
+    # CyberArk SCIM
+    CYBERARK_SCIM_ENABLED   = tostring(var.cyberark_scim_enabled)
+    CYBERARK_SCIM_APP_ID    = var.cyberark_scim_app_id
+    CYBERARK_SCIM_SCOPE     = var.cyberark_scim_scope
+    CYBERARK_SCIM_CLIENT_ID = var.cyberark_scim_client_id
   }
 
   # Secrets mapping (env var name -> Secret ARN)
@@ -97,7 +111,19 @@ locals {
   _admin_secrets = var.admin_password != "" ? {
     ADMIN_PASSWORD = module.secrets.admin_password_arn
   } : {}
-  secrets = merge(local._base_secrets, local._oidc_secrets, local._admin_secrets)
+  _cyberark_secrets = var.cyberark_client_secret != "" ? {
+    CYBERARK_CLIENT_SECRET = module.secrets.cyberark_client_secret_arn
+  } : {}
+  _scim_secrets = var.cyberark_scim_client_secret != "" ? {
+    CYBERARK_SCIM_CLIENT_SECRET = module.secrets.scim_client_secret_arn
+  } : {}
+  secrets = merge(
+    local._base_secrets,
+    local._oidc_secrets,
+    local._admin_secrets,
+    local._cyberark_secrets,
+    local._scim_secrets,
+  )
 }
 
 # -----------------------------------------------------------------------------
@@ -148,7 +174,14 @@ module "secrets" {
   oidc_client_secret  = var.oidc_client_secret
   create_admin_secret = var.admin_password != ""
   admin_password      = var.admin_password
-  tags                = local.common_tags
+
+  # CyberArk secrets
+  create_cyberark_secret      = var.cyberark_client_secret != ""
+  cyberark_client_secret      = var.cyberark_client_secret
+  create_scim_secret          = var.cyberark_scim_client_secret != ""
+  cyberark_scim_client_secret = var.cyberark_scim_client_secret
+
+  tags = local.common_tags
 }
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/environments/dev/terraform.tfvars.example
+++ b/infrastructure/environments/dev/terraform.tfvars.example
@@ -36,6 +36,22 @@ tf_state_bucket = "your-terraform-state-bucket"
 # admin_username = "admin"
 # admin_password = "YourStr0ng!Password"
 
+# CyberArk integration (optional - leave commented to disable)
+# cyberark_enabled       = true
+# cyberark_tenant_name   = "your-tenant-name"
+# cyberark_base_url      = "https://your-tenant.privilegecloud.cyberark.cloud"
+# cyberark_identity_url  = "https://your-tenant.id.cyberark.cloud"
+# cyberark_client_id     = "your-api-client-id"
+# cyberark_client_secret = "your-api-client-secret"
+# cyberark_uap_base_url  = "https://your-tenant.uap.cyberark.cloud/api"
+
+# CyberArk SCIM integration (optional - requires CyberArk identity URL above)
+# cyberark_scim_enabled       = true
+# cyberark_scim_app_id        = "your-scim-app-id"
+# cyberark_scim_scope         = "scim"
+# cyberark_scim_client_id     = "your-scim-client-id"
+# cyberark_scim_client_secret = "your-scim-client-secret"
+
 # Application settings
 log_level = "DEBUG"
 debug     = true

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -183,3 +183,85 @@ variable "debug" {
   type        = bool
   default     = true
 }
+
+# -----------------------------------------------------------------------------
+# CyberArk Integration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "cyberark_enabled" {
+  description = "Enable CyberArk integration"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_tenant_name" {
+  description = "CyberArk tenant name for auto-discovery of URLs"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_base_url" {
+  description = "CyberArk Privilege Cloud base URL"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_identity_url" {
+  description = "CyberArk Identity tenant URL"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_client_id" {
+  description = "CyberArk API client ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_client_secret" {
+  description = "CyberArk API client secret (stored in Secrets Manager)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cyberark_uap_base_url" {
+  description = "CyberArk UAP base URL for SIA policy collection"
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# CyberArk SCIM Integration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "cyberark_scim_enabled" {
+  description = "Enable CyberArk SCIM user collection"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_scim_app_id" {
+  description = "CyberArk Identity SCIM application ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_scope" {
+  description = "OAuth2 scope for SCIM token request"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_client_id" {
+  description = "CyberArk SCIM OAuth2 client ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_client_secret" {
+  description = "CyberArk SCIM OAuth2 client secret (stored in Secrets Manager)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -83,6 +83,20 @@ locals {
     OIDC_ISSUER      = var.oidc_issuer
     OIDC_CLIENT_ID   = var.oidc_client_id
     ADMIN_USERNAME   = var.admin_username
+
+    # CyberArk
+    CYBERARK_ENABLED      = tostring(var.cyberark_enabled)
+    CYBERARK_TENANT_NAME  = var.cyberark_tenant_name
+    CYBERARK_BASE_URL     = var.cyberark_base_url
+    CYBERARK_IDENTITY_URL = var.cyberark_identity_url
+    CYBERARK_CLIENT_ID    = var.cyberark_client_id
+    CYBERARK_UAP_BASE_URL = var.cyberark_uap_base_url
+
+    # CyberArk SCIM
+    CYBERARK_SCIM_ENABLED   = tostring(var.cyberark_scim_enabled)
+    CYBERARK_SCIM_APP_ID    = var.cyberark_scim_app_id
+    CYBERARK_SCIM_SCOPE     = var.cyberark_scim_scope
+    CYBERARK_SCIM_CLIENT_ID = var.cyberark_scim_client_id
   }
 
   _base_secrets = {
@@ -94,7 +108,19 @@ locals {
   _admin_secrets = var.admin_password != "" ? {
     ADMIN_PASSWORD = module.secrets.admin_password_arn
   } : {}
-  secrets = merge(local._base_secrets, local._oidc_secrets, local._admin_secrets)
+  _cyberark_secrets = var.cyberark_client_secret != "" ? {
+    CYBERARK_CLIENT_SECRET = module.secrets.cyberark_client_secret_arn
+  } : {}
+  _scim_secrets = var.cyberark_scim_client_secret != "" ? {
+    CYBERARK_SCIM_CLIENT_SECRET = module.secrets.scim_client_secret_arn
+  } : {}
+  secrets = merge(
+    local._base_secrets,
+    local._oidc_secrets,
+    local._admin_secrets,
+    local._cyberark_secrets,
+    local._scim_secrets,
+  )
 }
 
 # -----------------------------------------------------------------------------
@@ -146,7 +172,14 @@ module "secrets" {
   oidc_client_secret  = var.oidc_client_secret
   create_admin_secret = var.admin_password != ""
   admin_password      = var.admin_password
-  tags                = local.common_tags
+
+  # CyberArk secrets
+  create_cyberark_secret      = var.cyberark_client_secret != ""
+  cyberark_client_secret      = var.cyberark_client_secret
+  create_scim_secret          = var.cyberark_scim_client_secret != ""
+  cyberark_scim_client_secret = var.cyberark_scim_client_secret
+
+  tags = local.common_tags
 }
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/environments/prod/terraform.tfvars.example
+++ b/infrastructure/environments/prod/terraform.tfvars.example
@@ -35,6 +35,22 @@ oidc_client_secret = "..."  # Use Terraform variables or environment
 # admin_username = "admin"
 # admin_password = "YourStr0ng!Password"
 
+# CyberArk integration (optional)
+# cyberark_enabled       = true
+# cyberark_tenant_name   = "your-tenant-name"
+# cyberark_base_url      = "https://your-tenant.privilegecloud.cyberark.cloud"
+# cyberark_identity_url  = "https://your-tenant.id.cyberark.cloud"
+# cyberark_client_id     = "your-api-client-id"
+# cyberark_client_secret = "..."  # Use Terraform variables or environment
+# cyberark_uap_base_url  = "https://your-tenant.uap.cyberark.cloud/api"
+
+# CyberArk SCIM integration (optional - requires CyberArk identity URL above)
+# cyberark_scim_enabled       = true
+# cyberark_scim_app_id        = "your-scim-app-id"
+# cyberark_scim_scope         = "scim"
+# cyberark_scim_client_id     = "your-scim-client-id"
+# cyberark_scim_client_secret = "..."  # Use Terraform variables or environment
+
 # Application settings
 log_level = "INFO"
 debug     = false

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -173,3 +173,85 @@ variable "debug" {
   type        = bool
   default     = false
 }
+
+# -----------------------------------------------------------------------------
+# CyberArk Integration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "cyberark_enabled" {
+  description = "Enable CyberArk integration"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_tenant_name" {
+  description = "CyberArk tenant name for auto-discovery of URLs"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_base_url" {
+  description = "CyberArk Privilege Cloud base URL"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_identity_url" {
+  description = "CyberArk Identity tenant URL"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_client_id" {
+  description = "CyberArk API client ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_client_secret" {
+  description = "CyberArk API client secret (stored in Secrets Manager)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cyberark_uap_base_url" {
+  description = "CyberArk UAP base URL for SIA policy collection"
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# CyberArk SCIM Integration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "cyberark_scim_enabled" {
+  description = "Enable CyberArk SCIM user collection"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_scim_app_id" {
+  description = "CyberArk Identity SCIM application ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_scope" {
+  description = "OAuth2 scope for SCIM token request"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_client_id" {
+  description = "CyberArk SCIM OAuth2 client ID"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_scim_client_secret" {
+  description = "CyberArk SCIM OAuth2 client secret (stored in Secrets Manager)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/infrastructure/modules/secrets/main.tf
+++ b/infrastructure/modules/secrets/main.tf
@@ -76,6 +76,50 @@ resource "aws_secretsmanager_secret_version" "admin_password" {
 }
 
 # -----------------------------------------------------------------------------
+# CyberArk API Client Secret
+# -----------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "cyberark_client_secret" {
+  count = var.create_cyberark_secret ? 1 : 0
+
+  name        = "${var.project_name}/${var.environment}/cyberark-client-secret-${random_id.secret_suffix.hex}"
+  description = "CyberArk API client secret"
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-cyberark-secret"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "cyberark_client_secret" {
+  count = var.create_cyberark_secret && var.cyberark_client_secret != "" ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.cyberark_client_secret[0].id
+  secret_string = var.cyberark_client_secret
+}
+
+# -----------------------------------------------------------------------------
+# CyberArk SCIM Client Secret
+# -----------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "scim_client_secret" {
+  count = var.create_scim_secret ? 1 : 0
+
+  name        = "${var.project_name}/${var.environment}/cyberark-scim-client-secret-${random_id.secret_suffix.hex}"
+  description = "CyberArk SCIM OAuth2 client secret"
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-scim-secret"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "scim_client_secret" {
+  count = var.create_scim_secret && var.cyberark_scim_client_secret != "" ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.scim_client_secret[0].id
+  secret_string = var.cyberark_scim_client_secret
+}
+
+# -----------------------------------------------------------------------------
 # Application Secrets (combined JSON)
 # -----------------------------------------------------------------------------
 

--- a/infrastructure/modules/secrets/outputs.tf
+++ b/infrastructure/modules/secrets/outputs.tf
@@ -17,6 +17,16 @@ output "admin_password_arn" {
   value       = var.create_admin_secret ? aws_secretsmanager_secret.admin_password[0].arn : null
 }
 
+output "cyberark_client_secret_arn" {
+  description = "ARN of the CyberArk API client secret"
+  value       = var.create_cyberark_secret ? aws_secretsmanager_secret.cyberark_client_secret[0].arn : null
+}
+
+output "scim_client_secret_arn" {
+  description = "ARN of the CyberArk SCIM client secret"
+  value       = var.create_scim_secret ? aws_secretsmanager_secret.scim_client_secret[0].arn : null
+}
+
 output "app_secrets_arn" {
   description = "ARN of the app secrets"
   value       = length(var.app_secrets) > 0 ? aws_secretsmanager_secret.app_secrets[0].arn : null
@@ -28,6 +38,8 @@ output "all_secret_arns" {
     var.create_oidc_secret ? aws_secretsmanager_secret.oidc_client_secret[0].arn : null,
     aws_secretsmanager_secret.session_secret.arn,
     var.create_admin_secret ? aws_secretsmanager_secret.admin_password[0].arn : null,
+    var.create_cyberark_secret ? aws_secretsmanager_secret.cyberark_client_secret[0].arn : null,
+    var.create_scim_secret ? aws_secretsmanager_secret.scim_client_secret[0].arn : null,
     length(var.app_secrets) > 0 ? aws_secretsmanager_secret.app_secrets[0].arn : null
   ])
 }

--- a/infrastructure/modules/secrets/variables.tf
+++ b/infrastructure/modules/secrets/variables.tf
@@ -45,6 +45,32 @@ variable "admin_password" {
   sensitive   = true
 }
 
+variable "create_cyberark_secret" {
+  description = "Create CyberArk API client secret"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_client_secret" {
+  description = "CyberArk API client secret value"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "create_scim_secret" {
+  description = "Create CyberArk SCIM client secret"
+  type        = bool
+  default     = false
+}
+
+variable "cyberark_scim_client_secret" {
+  description = "CyberArk SCIM OAuth2 client secret value"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "app_secrets" {
   description = "Additional application secrets as key-value pairs"
   type        = map(string)


### PR DESCRIPTION
Wire all CyberArk environment variables through Terraform so they can be configured at deployment time via terraform.tfvars instead of only through the Settings UI after deployment.

Backend changes:
- Add SCIM env vars (CYBERARK_SCIM_ENABLED, CYBERARK_SCIM_APP_ID, CYBERARK_SCIM_SCOPE, CYBERARK_SCIM_CLIENT_ID, CYBERARK_SCIM_CLIENT_SECRET) and CYBERARK_TENANT_NAME to config.py
- Create ensure_cyberark_settings startup seeder that seeds CyberArkSettings DB row from env vars on first boot and syncs secrets on subsequent boots
- Update _get_or_create_cyberark_settings to include UAP, tenant, and SCIM fields when creating from env var defaults

Terraform changes:
- Add CyberArk + SCIM variables to dev and prod variables.tf
- Pass CyberArk env vars to ECS containers via main.tf locals
- Store cyberark_client_secret and cyberark_scim_client_secret in AWS Secrets Manager via the secrets module
- Add CyberArk/SCIM examples to terraform.tfvars.example for both dev and prod environments
- Update .env.example with SCIM and tenant name documentation

https://claude.ai/code/session_01EQJ2ozb4749hDoaykNNuKG