### PR TITLE
Fix [object Object] display for SIA policy tags and add JIT debug log…

### DIFF
--- a/backend/app/services/access_mapping.py
+++ b/backend/app/services/access_mapping.py
@@ -387,6 +387,14 @@ class AccessMappingService:
 
         all_policy_ids = direct_policy_ids | set(role_policies.keys())
         if not all_policy_ids:
+            logger.debug(
+                "JIT: no SIA policies matched for user %s "
+                "(direct=%d, role-based=%d, roles=%s)",
+                user_name,
+                len(direct_policy_ids),
+                len(role_policies),
+                list(role_names)[:10],
+            )
             return results
 
         # Get active policies
@@ -398,6 +406,12 @@ class AccessMappingService:
             )
         )
         policies = policies_result.scalars().all()
+        logger.debug(
+            "JIT: user %s matched %d policies (%d active)",
+            user_name,
+            len(all_policy_ids),
+            len(policies),
+        )
 
         for policy in policies:
             criteria = {}
@@ -412,6 +426,13 @@ class AccessMappingService:
                     pass
 
             matched_targets = await self._match_sia_criteria_to_targets(criteria)
+            logger.debug(
+                "JIT: policy %s (%s) criteria_keys=%s matched %d targets",
+                policy.policy_id,
+                policy.policy_name,
+                list(criteria.keys()) if criteria else [],
+                len(matched_targets),
+            )
 
             for (
                 target_type,

--- a/frontend/src/components/cyberark/SIAPolicyDetailPanel.tsx
+++ b/frontend/src/components/cyberark/SIAPolicyDetailPanel.tsx
@@ -35,9 +35,17 @@ export function SIAPolicyDetailPanel({
   const renderCriteria = (criteria: Record<string, unknown>) => {
     return Object.entries(criteria).map(([key, value]) => {
       if (!value || (Array.isArray(value) && value.length === 0)) return null;
-      const displayValue = Array.isArray(value)
-        ? value.join(", ")
-        : String(value);
+      let displayValue: string;
+      if (Array.isArray(value)) {
+        displayValue = value.join(", ");
+      } else if (typeof value === "object" && value !== null) {
+        // Nested objects like tags: {"env": ["dev"], "os": ["linux", "unix"]}
+        displayValue = Object.entries(value as Record<string, unknown>)
+          .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`)
+          .join("; ");
+      } else {
+        displayValue = String(value);
+      }
       return <DetailRow key={key} label={key} value={displayValue} />;
     });
   };


### PR DESCRIPTION
…ging

The renderCriteria function in SIAPolicyDetailPanel used String(value) on nested tag objects, producing "[object Object]". Now handles nested dicts by formatting as "key: value1, value2; key2: value3".

Also adds debug-level logging to _compute_jit_access to trace principal matching and target criteria matching steps for diagnosing access map visibility issues.

https://claude.ai/code/session_014CyJFnndR9Q8mPPyWKUbHJ