### PR TITLE
Replace ReactFlow Controls with custom ZoomControls component

### DIFF
--- a/frontend/src/components/access-mapping/AccessMappingCanvas.tsx
+++ b/frontend/src/components/access-mapping/AccessMappingCanvas.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Background,
-  Controls,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -11,6 +10,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 
+import { ZoomControls } from "@/components/common/ZoomControls";
 import {
   UserNode,
   RoleNode,
@@ -172,13 +172,7 @@ function AccessMappingCanvasInner({ data, filters }: AccessMappingCanvasProps) {
           size={1}
           className="bg-gray-50 dark:bg-gray-900"
         />
-        <Controls
-          showInteractive={false}
-          showFitView={true}
-          showZoom={true}
-          position="bottom-right"
-          className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg [&>button]:border-gray-200 [&>button]:dark:border-gray-700"
-        />
+        <ZoomControls />
       </ReactFlow>
 
       {/* Collapse/Expand All controls */}

--- a/frontend/src/components/common/ZoomControls.test.tsx
+++ b/frontend/src/components/common/ZoomControls.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ZoomControls } from "./ZoomControls";
+
+const mockZoomIn = vi.fn();
+const mockZoomOut = vi.fn();
+const mockFitView = vi.fn();
+
+vi.mock("reactflow", () => ({
+  useReactFlow: () => ({
+    zoomIn: mockZoomIn,
+    zoomOut: mockZoomOut,
+    fitView: mockFitView,
+  }),
+  useStore: (selector: (state: { transform: number[] }) => number) =>
+    selector({ transform: [0, 0, 0.75] }),
+}));
+
+describe("ZoomControls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders zoom in, zoom out, and fit view buttons", () => {
+    render(<ZoomControls />);
+    expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+    expect(screen.getByLabelText("Fit to view")).toBeInTheDocument();
+  });
+
+  it("displays the current zoom percentage", () => {
+    render(<ZoomControls />);
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("calls zoomOut when minus button is clicked", () => {
+    render(<ZoomControls />);
+    fireEvent.click(screen.getByLabelText("Zoom out"));
+    expect(mockZoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls zoomIn when plus button is clicked", () => {
+    render(<ZoomControls />);
+    fireEvent.click(screen.getByLabelText("Zoom in"));
+    expect(mockZoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fitView when fit-to-view button is clicked", () => {
+    render(<ZoomControls />);
+    fireEvent.click(screen.getByLabelText("Fit to view"));
+    expect(mockFitView).toHaveBeenCalledTimes(1);
+    expect(mockFitView).toHaveBeenCalledWith({ duration: 300, padding: 0.2 });
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<ZoomControls className="custom-class" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains("custom-class")).toBe(true);
+  });
+});

--- a/frontend/src/components/common/ZoomControls.tsx
+++ b/frontend/src/components/common/ZoomControls.tsx
@@ -1,0 +1,50 @@
+import { useReactFlow, useStore } from "reactflow";
+import { Minus, Plus, Maximize2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ZoomControlsProps {
+  className?: string;
+}
+
+export function ZoomControls({ className }: ZoomControlsProps) {
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const zoom = useStore((state) => state.transform[2]);
+  const zoomPercentage = Math.round(zoom * 100);
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-4 right-4 z-10 flex items-center gap-2",
+        className,
+      )}
+    >
+      <div className="flex items-center bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg divide-x divide-gray-200 dark:divide-gray-700">
+        <button
+          onClick={() => zoomOut()}
+          className="p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-200 transition-colors rounded-l-lg"
+          aria-label="Zoom out"
+        >
+          <Minus className="h-3.5 w-3.5" />
+        </button>
+        <span className="px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300 min-w-[3rem] text-center select-none">
+          {zoomPercentage}%
+        </span>
+        <button
+          onClick={() => zoomIn()}
+          className="p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-200 transition-colors rounded-r-lg"
+          aria-label="Zoom in"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <button
+        onClick={() => fitView({ duration: 300, padding: 0.2 })}
+        className="p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+        aria-label="Fit to view"
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/topology/TopologyCanvas.test.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.test.tsx
@@ -44,7 +44,6 @@ vi.mock("reactflow", () => ({
     </div>
   ),
   Background: () => <div data-testid="react-flow-background" />,
-  Controls: () => <div data-testid="react-flow-controls" />,
   ReactFlowProvider: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -54,6 +53,11 @@ vi.mock("reactflow", () => ({
   ) => [initialEdges, vi.fn(), vi.fn()],
   useReactFlow: () => ({ fitView: vi.fn() }),
   BackgroundVariant: { Dots: "dots" },
+}));
+
+// Mock ZoomControls
+vi.mock("@/components/common/ZoomControls", () => ({
+  ZoomControls: () => <div data-testid="zoom-controls" />,
 }));
 
 // Mock the layout calculator
@@ -132,9 +136,9 @@ describe("TopologyCanvas", () => {
     expect(screen.getByTestId("react-flow-background")).toBeInTheDocument();
   });
 
-  it("renders ReactFlow controls", () => {
+  it("renders zoom controls", () => {
     render(<TopologyCanvas data={mockTopologyData} />);
-    expect(screen.getByTestId("react-flow-controls")).toBeInTheDocument();
+    expect(screen.getByTestId("zoom-controls")).toBeInTheDocument();
   });
 
   it("calls onNodeClick when node is clicked", () => {

--- a/frontend/src/components/topology/TopologyCanvas.tsx
+++ b/frontend/src/components/topology/TopologyCanvas.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Background,
-  Controls,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -12,6 +11,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 
+import { ZoomControls } from "@/components/common/ZoomControls";
 import {
   VPCNode,
   SubnetNode,
@@ -183,13 +183,7 @@ function TopologyCanvasInner({ data, onNodeClick }: TopologyCanvasProps) {
           size={1}
           className="bg-gray-50 dark:bg-gray-900"
         />
-        <Controls
-          showInteractive={false}
-          showFitView={true}
-          showZoom={true}
-          position="bottom-right"
-          className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg [&>button]:border-gray-200 [&>button]:dark:border-gray-700"
-        />
+        <ZoomControls />
       </ReactFlow>
 
       {/* Collapse/Expand All controls */}


### PR DESCRIPTION
## Summary
This PR replaces the built-in ReactFlow `Controls` component with a custom `ZoomControls` component across the application. The new component provides the same zoom and fit-to-view functionality while offering better styling consistency and customization options.

## Key Changes
- **New Component**: Created `ZoomControls` component (`frontend/src/components/common/ZoomControls.tsx`) with:
  - Zoom in/out buttons with Minus/Plus icons from lucide-react
  - Real-time zoom percentage display
  - Fit-to-view button with Maximize2 icon
  - Full dark mode support
  - Support for custom className prop
  - Positioned absolutely at bottom-right with z-10

- **Comprehensive Tests**: Added full test suite (`frontend/src/components/common/ZoomControls.test.tsx`) covering:
  - Button rendering and accessibility labels
  - Zoom percentage display
  - Click handlers for all three controls
  - Custom className application
  - Mocking of ReactFlow hooks

- **Component Integration**: Replaced ReactFlow's `Controls` component in:
  - `AccessMappingCanvas.tsx`
  - `TopologyCanvas.tsx`

- **Test Updates**: Updated `TopologyCanvas.test.tsx` to:
  - Remove mock for ReactFlow's `Controls`
  - Add mock for new `ZoomControls` component
  - Update test assertion to verify zoom controls render

## Implementation Details
- The `ZoomControls` component uses ReactFlow's `useReactFlow()` hook for zoom operations and `useStore()` to access the current zoom level
- Zoom percentage is calculated from the transform state and displayed as a rounded percentage
- The fit-to-view action is configured with 300ms duration and 0.2 padding for smooth animation
- Styling uses Tailwind CSS with consistent dark mode support matching the application's design system

https://claude.ai/code/session_01PDGLNiSg4ACDeNsbURkfMq