### PR TITLE
Integrate CyberArk Users into tabbed Resources page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -19,9 +19,6 @@ vi.mock("@/pages", () => ({
   CyberArkDashboardPage: () => (
     <div data-testid="cyberark-dashboard-page">CyberArk Dashboard Content</div>
   ),
-  CyberArkUsersPage: () => (
-    <div data-testid="cyberark-users-page">CyberArk Users Content</div>
-  ),
   AccessMappingPage: () => (
     <div data-testid="access-mapping-page">Access Mapping Content</div>
   ),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import {
   SetupPage,
   CyberArkPage,
   CyberArkDashboardPage,
-  CyberArkUsersPage,
   AccessMappingPage,
 } from "@/pages";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -68,10 +67,6 @@ function App() {
                     element={<CyberArkDashboardPage />}
                   />
                   <Route path="cyberark" element={<CyberArkPage />} />
-                  <Route
-                    path="cyberark-users"
-                    element={<CyberArkUsersPage />}
-                  />
                   <Route
                     path="access-mapping"
                     element={<AccessMappingPage />}

--- a/frontend/src/components/cyberark/CyberArkTabNavigation.tsx
+++ b/frontend/src/components/cyberark/CyberArkTabNavigation.tsx
@@ -1,4 +1,4 @@
-import { Lock, ShieldCheck, Zap } from "lucide-react";
+import { Lock, ShieldCheck, Users, Zap } from "lucide-react";
 import type { CyberArkResourceType } from "@/types";
 
 interface Tab {
@@ -10,6 +10,7 @@ interface Tab {
 const tabs: Tab[] = [
   { key: "safes", label: "Safes", icon: Lock },
   { key: "roles", label: "Roles", icon: ShieldCheck },
+  { key: "users", label: "Users", icon: Users },
   { key: "sia-policies", label: "SIA Policies", icon: Zap },
 ];
 

--- a/frontend/src/components/cyberark/UserList.tsx
+++ b/frontend/src/components/cyberark/UserList.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import {
+  PageLoading,
+  EmptyState,
+  SearchInput,
+  StatusBadge,
+} from "@/components/common";
+import { ResourceTable } from "@/components/resources";
+import { useCyberArkUsers } from "@/hooks";
+import type { CyberArkIdentityUser } from "@/types";
+
+export function UserList() {
+  const [search, setSearch] = useState("");
+
+  const filters = search ? { search } : undefined;
+  const { data, isLoading, error } = useCyberArkUsers(filters);
+
+  const columns = [
+    {
+      key: "username",
+      header: "Username",
+      render: (user: CyberArkIdentityUser) => (
+        <div>
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            {user.user_name}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {user.user_id}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: "display_name",
+      header: "Display Name",
+      render: (user: CyberArkIdentityUser) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {user.display_name ?? "-"}
+        </span>
+      ),
+    },
+    {
+      key: "email",
+      header: "Email",
+      render: (user: CyberArkIdentityUser) => (
+        <span className="text-gray-700 dark:text-gray-300">
+          {user.email ?? "-"}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (user: CyberArkIdentityUser) => (
+        <StatusBadge status={user.active ? "active" : "inactive"} size="sm" />
+      ),
+    },
+  ];
+
+  if (isLoading) {
+    return <PageLoading />;
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        title="Error loading users"
+        description="There was an error loading the CyberArk users. Please try again."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          {data?.meta.total || 0} users found
+        </p>
+      </div>
+
+      <SearchInput
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        onClear={() => setSearch("")}
+        placeholder="Search users..."
+      />
+
+      {data?.data.length === 0 ? (
+        <EmptyState
+          title="No users found"
+          description="No CyberArk users match your current search."
+        />
+      ) : (
+        <ResourceTable
+          columns={columns}
+          data={data?.data || []}
+          keyExtractor={(user) => user.user_id}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -15,7 +15,6 @@ import {
   ChevronsLeft,
   ChevronsRight,
   Lock,
-  Users,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -59,7 +58,6 @@ const navigationSections: NavSection[] = [
     items: [
       { name: "Dashboard", href: "/cyberark-dashboard", icon: LayoutDashboard },
       { name: "Resources", href: "/cyberark", icon: Lock },
-      { name: "Users", href: "/cyberark-users", icon: Users },
       { name: "Access Mapping", href: "/access-mapping", icon: Map },
     ],
   },

--- a/frontend/src/pages/CyberArkDashboard.tsx
+++ b/frontend/src/pages/CyberArkDashboard.tsx
@@ -84,7 +84,7 @@ export function CyberArkDashboardPage() {
           icon={<Users className="h-5 w-5 text-blue-600" />}
           value={totalUsers}
           subtitle={`${activeUsers} active`}
-          href="/cyberark-users"
+          href="/cyberark"
           linkText="View users"
           loading={usersLoading}
         />

--- a/frontend/src/pages/CyberArkPage.tsx
+++ b/frontend/src/pages/CyberArkPage.tsx
@@ -3,6 +3,7 @@ import { Shield } from "lucide-react";
 import { CyberArkTabNavigation } from "@/components/cyberark/CyberArkTabNavigation";
 import { SafeList } from "@/components/cyberark/SafeList";
 import { RoleList } from "@/components/cyberark/RoleList";
+import { UserList } from "@/components/cyberark/UserList";
 import { SIAPolicyList } from "@/components/cyberark/SIAPolicyList";
 import type { CyberArkResourceType } from "@/types";
 
@@ -21,7 +22,7 @@ export function CyberArkPage() {
             CyberArk Resources
           </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Identity roles, Privilege Cloud safes, and SIA policies
+            Identity users and roles, Privilege Cloud safes, and SIA policies
           </p>
         </div>
       </div>
@@ -33,6 +34,7 @@ export function CyberArkPage() {
       <div>
         {activeTab === "safes" && <SafeList />}
         {activeTab === "roles" && <RoleList />}
+        {activeTab === "users" && <UserList />}
         {activeTab === "sia-policies" && <SIAPolicyList />}
       </div>
     </div>

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -11,5 +11,4 @@ export { AuthCallbackPage } from "./AuthCallbackPage";
 export { SetupPage } from "./SetupPage";
 export { CyberArkPage } from "./CyberArkPage";
 export { CyberArkDashboardPage } from "./CyberArkDashboard";
-export { CyberArkUsersPage } from "./CyberArkUsersPage";
 export { AccessMappingPage } from "./AccessMappingPage";

--- a/frontend/src/types/cyberark.ts
+++ b/frontend/src/types/cyberark.ts
@@ -112,7 +112,7 @@ export interface CyberArkSIAPolicyDetail extends CyberArkSIAPolicy {
 // CyberArk Page Types
 // =============================================================================
 
-export type CyberArkResourceType = "safes" | "roles" | "sia-policies";
+export type CyberArkResourceType = "safes" | "roles" | "sia-policies" | "users";
 
 export interface CyberArkFilters {
   search?: string;


### PR DESCRIPTION
## Summary
Consolidates the CyberArk Users management into the main CyberArk Resources page as a tab, removing the separate dedicated users page. This improves navigation by co-locating all CyberArk resource management in a single interface.

## Key Changes
- **New Component**: Added `UserList.tsx` component to display CyberArk Identity users with search, filtering, and status indicators
- **Navigation Refactor**: 
  - Removed dedicated `/cyberark-users` route and `CyberArkUsersPage`
  - Added "Users" tab to the CyberArk Resources page alongside Safes, Roles, and SIA Policies
  - Updated sidebar navigation to remove the separate Users link
- **Tab Navigation**: Updated `CyberArkTabNavigation` to include Users tab with icon
- **Type Updates**: Extended `CyberArkResourceType` to include "users"
- **Dashboard Link**: Updated the Users card on the CyberArk Dashboard to link to `/cyberark` instead of `/cyberark-users`
- **Test Updates**: Removed mock for `CyberArkUsersPage` from test file

## Implementation Details
- The `UserList` component follows the existing pattern used by `SafeList` and `RoleList`, utilizing the `useCyberArkUsers` hook
- Displays user information including username, user ID, display name, email, and active status
- Includes search functionality and proper loading/error states
- Uses existing UI components (`ResourceTable`, `SearchInput`, `StatusBadge`, `EmptyState`)

https://claude.ai/code/session_01MeJSrwX4s6KM9hArjMA815