### PR TITLE
Add support for SIA policy resource extraction with nested metadata

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -158,11 +158,11 @@ class Settings(BaseSettings):
         description="Terraform resource type for CyberArk User",
     )
     cyberark_tf_sia_vm_policy_type: str = Field(
-        default="idsec_sia_vm_policy",
+        default="idsec_policy_vm",
         description="Terraform resource type for SIA VM policy",
     )
     cyberark_tf_sia_db_policy_type: str = Field(
-        default="idsec_sia_db_policy",
+        default="idsec_policy_db",
         description="Terraform resource type for SIA DB policy",
     )
 

--- a/backend/app/parsers/terraform.py
+++ b/backend/app/parsers/terraform.py
@@ -353,10 +353,22 @@ class TerraformStateParser:
         id_mappings[settings.cyberark_tf_account_type] = "id"
         id_mappings[settings.cyberark_tf_role_type] = "role_name"
         id_mappings[settings.cyberark_tf_user_type] = "username"
-        id_mappings[settings.cyberark_tf_sia_vm_policy_type] = "name"
-        id_mappings[settings.cyberark_tf_sia_db_policy_type] = "name"
+        # SIA/UAP policies store the name nested under metadata
+        id_mappings[settings.cyberark_tf_sia_vm_policy_type] = "metadata.name"
+        id_mappings[settings.cyberark_tf_sia_db_policy_type] = "metadata.name"
 
         id_field = id_mappings.get(resource_type, "id")
+
+        # Support dot-notation for nested attributes (e.g. "metadata.name")
+        if "." in id_field:
+            value: Any = attributes
+            for key in id_field.split("."):
+                if isinstance(value, dict):
+                    value = value.get(key)
+                else:
+                    return None
+            return value if isinstance(value, str) else None
+
         return attributes.get(id_field)
 
 


### PR DESCRIPTION
## Summary
This PR adds support for extracting CyberArk SIA (Secure Infrastructure Access) VM and DB policy resources from Terraform state files, with proper handling of nested metadata attributes.

## Key Changes
- **Updated resource type mappings** in `config.py`:
  - Changed `idsec_sia_vm_policy` → `idsec_policy_vm`
  - Changed `idsec_sia_db_policy` → `idsec_policy_db`

- **Enhanced resource ID extraction** in `terraform.py`:
  - Added support for dot-notation path traversal (e.g., `metadata.name`) to extract nested attributes
  - Updated SIA policy types to use `metadata.name` instead of top-level `name` field
  - Implemented recursive dictionary traversal with proper type checking and None handling

- **Comprehensive test coverage** in `test_terraform_parser.py`:
  - Added type mapping validation tests for both VM and DB policies
  - Added end-to-end extraction test for VM policy with complex nested structure
  - Added unit tests for nested metadata extraction with edge cases (missing metadata, missing name field)

## Implementation Details
The nested attribute extraction uses a simple dot-notation parser that splits the path and traverses the dictionary hierarchy. It safely handles missing keys and non-dict values by returning None, ensuring graceful degradation when expected fields are absent.

https://claude.ai/code/session_016SXZHURtFwdyEL3L4YvzCk