### PR TITLE
Fix JIT access mapping: case-insensitive tags and instance-level acco…

### DIFF
--- a/backend/app/api/routes/resources.py
+++ b/backend/app/api/routes/resources.py
@@ -307,6 +307,7 @@ async def _sync_ec2_instances(db: AsyncSession, instances: list, region_id: int)
             existing.launch_time = instance_data.get("launch_time")
             existing.tags = json.dumps(instance_data.get("tags", {}))
             existing.platform = instance_data.get("platform", "linux")
+            existing.owner_account_id = instance_data.get("owner_account_id")
             existing.is_deleted = False
             existing.deleted_at = None
         else:
@@ -327,6 +328,7 @@ async def _sync_ec2_instances(db: AsyncSession, instances: list, region_id: int)
                 launch_time=instance_data.get("launch_time"),
                 tags=json.dumps(instance_data.get("tags", {})),
                 platform=instance_data.get("platform", "linux"),
+                owner_account_id=instance_data.get("owner_account_id"),
                 is_deleted=False,
             )
             db.add(new_instance)
@@ -392,6 +394,7 @@ async def _sync_rds_instances(db: AsyncSession, instances: list, region_id: int)
             existing.vpc_id = instance_data.get("vpc_id")
             existing.availability_zone = instance_data.get("availability_zone")
             existing.multi_az = instance_data.get("multi_az", False)
+            existing.owner_account_id = instance_data.get("owner_account_id")
             existing.tags = json.dumps(instance_data.get("tags", {}))
             existing.is_deleted = False
             existing.deleted_at = None
@@ -411,6 +414,7 @@ async def _sync_rds_instances(db: AsyncSession, instances: list, region_id: int)
                 vpc_id=instance_data.get("vpc_id"),
                 availability_zone=instance_data.get("availability_zone"),
                 multi_az=instance_data.get("multi_az", False),
+                owner_account_id=instance_data.get("owner_account_id"),
                 tags=json.dumps(instance_data.get("tags", {})),
                 is_deleted=False,
             )

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -191,6 +191,19 @@ async def init_db() -> None:
         except Exception:
             pass  # Column already exists
 
+    # Add owner_account_id column to ec2_instances and rds_instances (if missing)
+    async with get_engine().begin() as conn:
+        for tbl in ("ec2_instances", "rds_instances"):
+            try:
+                await conn.execute(
+                    text(
+                        f"ALTER TABLE {tbl} " "ADD COLUMN owner_account_id VARCHAR(20)"
+                    )
+                )
+                logger.info("Added column owner_account_id to %s", tbl)
+            except Exception:
+                pass  # Column already exists
+
     # Fix any NULL values in NOT-NULL integer columns (from earlier bugs)
     async with get_engine().begin() as conn:
         for stmt in [

--- a/backend/app/models/resources.py
+++ b/backend/app/models/resources.py
@@ -153,6 +153,9 @@ class EC2Instance(Base):
     # Platform (AWS returns "windows" for Windows instances; absent for Linux)
     platform: Mapped[Optional[str]] = mapped_column(String(30), nullable=True)
 
+    # Owner account (Reservation.OwnerId from DescribeInstances)
+    owner_account_id: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+
     # Metadata
     launch_time: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     tags: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON string
@@ -224,6 +227,9 @@ class RDSInstance(Base):
     vpc_id: Mapped[Optional[str]] = mapped_column(String(30), nullable=True)
     availability_zone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     multi_az: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # Owner account (extracted from DBInstanceArn)
+    owner_account_id: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
 
     # Metadata
     tags: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON string

--- a/backend/tests/test_ec2_collector.py
+++ b/backend/tests/test_ec2_collector.py
@@ -1,6 +1,8 @@
-"""Tests for the EC2 collector, specifically platform normalization."""
+"""Tests for EC2/RDS collectors: platform normalization,
+owner_account_id extraction, and ARN parsing."""
 
 from app.collectors.ec2 import EC2Collector
+from app.collectors.rds import RDSCollector
 
 
 class TestNormalizePlatform:
@@ -39,3 +41,54 @@ class TestNormalizePlatform:
             EC2Collector._normalize_platform(None, "Red Hat Enterprise Linux")
             == "linux"
         )
+
+
+class TestParseInstanceOwnerAccountId:
+    """Tests that _parse_instance includes owner_account_id from Reservation."""
+
+    def test_owner_account_id_included(self):
+        """owner_account_id from Reservation.OwnerId is in parsed output."""
+        collector = EC2Collector(region="us-east-1")
+        instance = {
+            "InstanceId": "i-123",
+            "State": {"Name": "running"},
+            "InstanceType": "t3.micro",
+            "Tags": [],
+        }
+        result = collector._parse_instance(instance, owner_id="475601244925")
+        assert result is not None
+        assert result["owner_account_id"] == "475601244925"
+
+    def test_owner_account_id_none_when_not_provided(self):
+        """owner_account_id defaults to None when not passed."""
+        collector = EC2Collector(region="us-east-1")
+        instance = {
+            "InstanceId": "i-456",
+            "State": {"Name": "stopped"},
+            "InstanceType": "t3.small",
+            "Tags": [],
+        }
+        result = collector._parse_instance(instance)
+        assert result is not None
+        assert result["owner_account_id"] is None
+
+
+class TestRDSExtractAccountFromArn:
+    """Tests for RDSCollector._extract_account_from_arn."""
+
+    def test_valid_arn(self):
+        arn = "arn:aws:rds:us-east-1:123456789012:db:mydb"
+        assert RDSCollector._extract_account_from_arn(arn) == "123456789012"
+
+    def test_none_arn(self):
+        assert RDSCollector._extract_account_from_arn(None) is None
+
+    def test_empty_arn(self):
+        assert RDSCollector._extract_account_from_arn("") is None
+
+    def test_malformed_arn(self):
+        assert RDSCollector._extract_account_from_arn("not:an:arn") is None
+
+    def test_cluster_arn(self):
+        arn = "arn:aws:rds:eu-west-1:999888777666:cluster:my-cluster"
+        assert RDSCollector._extract_account_from_arn(arn) == "999888777666"


### PR DESCRIPTION
…unt ID

Tag value comparison in _target_matches_criteria was case-sensitive, causing "Terraform" != "terraform" mismatches. Now normalizes both sides to lowercase before comparing. Tag keys remain case-sensitive per AWS.

Account ID matching previously relied on aws_account_id config env var which fails when unset. Now stores owner_account_id per instance:
- EC2: extracted from Reservation.OwnerId in DescribeInstances
- RDS: extracted from DBInstanceArn (arn:aws:rds:region:account-id:db:name)

This supports multi-account scenarios where policies specify account_ids lists and instances may belong to different accounts.

https://claude.ai/code/session_012x63w5RdeADV5nYXMmY4gU