### PR TITLE
Fix CVE-2026-24049 by upgrading wheel and setuptools

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Upgrade base Python packaging tools to fix CVE-2026-24049 (wheel path traversal)
+# - wheel>=0.46.2 fixes the CVE directly
+# - setuptools>=76.0.0 removes vendored wheel from setuptools/_vendor/
+RUN pip install --no-cache-dir --upgrade pip setuptools>=76.0.0 wheel>=0.46.2
+
 # Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
This change addresses a security vulnerability (CVE-2026-24049) related to wheel path traversal by upgrading Python packaging tools in the Docker build process.

## Key Changes
- Added explicit upgrade of `pip`, `setuptools>=76.0.0`, and `wheel>=0.46.2` in the Dockerfile
- The upgrade occurs before installing application dependencies to ensure all subsequent package installations use the patched versions
- `setuptools>=76.0.0` removes the vendored wheel from `setuptools/_vendor/`, eliminating a potential attack vector
- `wheel>=0.46.2` directly fixes the CVE-2026-24049 path traversal vulnerability

## Implementation Details
The upgrade is performed as a separate RUN instruction in the Dockerfile to:
1. Ensure the base Python packaging tools are patched before any application dependencies are installed
2. Maintain clarity in the build process by separating tool upgrades from application dependency installation
3. Use `--no-cache-dir` to keep the Docker image size minimal

https://claude.ai/code/session_01Lsw55F29gCnGiByCDfuD5X