### PR TITLE
Pin jaraco.context dependency to address CVE-2026-23949

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,6 @@ email-validator==2.1.0
 
 # Utilities
 python-dateutil==2.8.2
+
+# Security: transitive dependency pinned for CVE-2026-23949 (path traversal)
+jaraco.context>=6.1.0


### PR DESCRIPTION
## Summary
This change pins the `jaraco.context` transitive dependency to version 6.1.0 or higher to address a path traversal vulnerability (CVE-2026-23949).

## Changes
- Added explicit version constraint for `jaraco.context>=6.1.0` in backend requirements
- This dependency is pinned as a security measure to ensure the vulnerability fix is included in all installations

## Details
The `jaraco.context` package is a transitive dependency that was previously unpinned. By explicitly requiring version 6.1.0 or later, we ensure that all environments using this codebase include the patched version that resolves the path traversal security issue.

https://claude.ai/code/session_01R2uAhtgEcoTu9NWiWxhHwd