### PR TITLE
Upgrade pip to >=25.3 to fix CVE-2025-8869 symlink vulnerability

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=25.3"
           pip install -r requirements-dev.txt
 
       - name: Check code formatting with Black
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=25.3"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=25.3"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -33,8 +33,10 @@ jobs:
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
 
-      - name: Install pip-audit
-        run: pip install pip-audit
+      - name: Upgrade pip and install pip-audit
+        run: |
+          python -m pip install --upgrade "pip>=25.3"
+          pip install pip-audit
 
       - name: Run pip-audit
         run: |
@@ -100,8 +102,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Bandit
-        run: pip install bandit[toml]
+      - name: Upgrade pip and install Bandit
+        run: |
+          python -m pip install --upgrade "pip>=25.3"
+          pip install bandit[toml]
 
       - name: Run Bandit security scan
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,10 +29,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade base Python packaging tools to fix CVE-2026-24049 (wheel path traversal)
-# - wheel>=0.46.2 fixes the CVE directly
+# Upgrade base Python packaging tools to fix:
+# - CVE-2025-8869: pip symlink path traversal in tar extraction (pip>=25.3)
+# - CVE-2026-24049: wheel path traversal (wheel>=0.46.2)
 # - setuptools>=76.0.0 removes vendored wheel from setuptools/_vendor/
-RUN pip install --no-cache-dir --upgrade pip setuptools>=76.0.0 wheel>=0.46.2
+RUN pip install --no-cache-dir --upgrade "pip>=25.3" "setuptools>=76.0.0" "wheel>=0.46.2"
 
 # Install Python dependencies
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
This PR upgrades pip to version 25.3 or higher across all CI/CD workflows and the Docker build process to address CVE-2025-8869, a symlink path traversal vulnerability in pip's tar extraction logic.

## Key Changes
- **Security workflows** (`security-scan.yml`): Updated pip-audit and Bandit installation steps to explicitly upgrade pip to >=25.3 before installing security tools
- **Backend tests** (`backend-tests.yml`): Updated all three test jobs to upgrade pip to >=25.3 instead of the latest version
- **Docker build** (`Dockerfile`): 
  - Upgraded pip requirement to >=25.3 in the base Python packaging tools installation
  - Updated comments to document both CVE-2025-8869 (pip symlink traversal) and CVE-2026-24049 (wheel path traversal)
  - Added explicit version constraints for all three tools: pip, setuptools, and wheel

## Implementation Details
- Used explicit version constraints (`"pip>=25.3"`) in pip install commands to ensure the minimum vulnerable version is addressed
- Maintained consistency across all CI/CD workflows and container builds
- Preserved existing version constraints for setuptools (>=76.0.0) and wheel (>=0.46.2) which address related packaging vulnerabilities

https://claude.ai/code/session_011JZPXdNYTPGRZPNdjiJQLZ