### PR TITLE
Fix audit page not loading due to response field name mismatch

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -635,10 +635,11 @@ export interface AuditLogEntry {
 }
 
 export interface AuditLogsResponse {
-  logs: AuditLogEntry[];
+  data: AuditLogEntry[];
   total: number;
   page: number;
   page_size: number;
+  has_more: boolean;
 }
 
 export async function getAuditLogs(params?: {

--- a/frontend/src/components/settings/AuditLogPanel.tsx
+++ b/frontend/src/components/settings/AuditLogPanel.tsx
@@ -30,7 +30,7 @@ export function AuditLogPanel() {
         action: actionFilter || undefined,
         username: usernameFilter || undefined,
       });
-      setLogs(data.logs);
+      setLogs(data.data);
       setTotal(data.total);
     } catch {
       setError("Failed to load audit logs");


### PR DESCRIPTION
The backend returns audit log entries under a "data" field but the frontend AuditLogsResponse interface expected a "logs" field. This caused data.logs to be undefined, which threw an error caught by the component's catch block, displaying "Failed to load audit logs".

Update the frontend interface to match the backend schema (data instead of logs, add missing has_more field) and fix the component to read from data.data.

https://claude.ai/code/session_01Qy8oz68ZG9WcAcEnUTC7gJ