### PR TITLE
Fix audit log crash and CodeQL log injection alerts

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -635,10 +635,11 @@ export interface AuditLogEntry {
 }
 
 export interface AuditLogsResponse {
-  logs: AuditLogEntry[];
+  data: AuditLogEntry[];
   total: number;
   page: number;
   page_size: number;
+  has_more: boolean;
 }
 
 export async function getAuditLogs(params?: {

--- a/frontend/src/components/settings/AuditLogPanel.tsx
+++ b/frontend/src/components/settings/AuditLogPanel.tsx
@@ -30,7 +30,7 @@ export function AuditLogPanel() {
         action: actionFilter || undefined,
         username: usernameFilter || undefined,
       });
-      setLogs(data.logs);
+      setLogs(data.data);
       setTotal(data.total);
     } catch {
       setError("Failed to load audit logs");


### PR DESCRIPTION
## Summary
- Fix audit log panel crash: backend returns `data` field but frontend expected `logs`, causing `undefined.length` TypeError
- Fix CodeQL log injection alerts by sanitizing usernames and casting path parameter IDs in log statements
- Resolve merge conflicts between main and develop

## Test plan
- [x] TypeScript type check passes
- [x] All 724 Vitest tests pass (55 test files)
- [x] ESLint passes with no errors
- [ ] Navigate to Settings > Audit tab and verify the log table renders without console errors
- [ ] Verify pagination and filtering work on the audit log panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)