### PR TITLE
test: Close frontend test coverage gaps (52% → 80%)

### DIFF
--- a/frontend/src/components/access-mapping/AccessMappingDetailPanel.test.tsx
+++ b/frontend/src/components/access-mapping/AccessMappingDetailPanel.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { AccessMappingDetailPanel } from "./AccessMappingDetailPanel";
+
+// =============================================================================
+// Mock hooks
+// =============================================================================
+
+let mockEC2Instance: Record<string, unknown> | null = null;
+let mockEC2Loading = false;
+let mockRDSInstance: Record<string, unknown> | null = null;
+let mockRDSLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useEC2Instance: () => ({
+    data: mockEC2Instance,
+    isLoading: mockEC2Loading,
+  }),
+  useRDSInstance: () => ({
+    data: mockRDSInstance,
+    isLoading: mockRDSLoading,
+  }),
+}));
+
+describe("AccessMappingDetailPanel", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEC2Instance = null;
+    mockEC2Loading = false;
+    mockRDSInstance = null;
+    mockRDSLoading = false;
+  });
+
+  it("renders account detail panel for access-account type", () => {
+    render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-account",
+          nodeData: {
+            accountName: "root-account",
+            accountId: "acc-1",
+            safeName: "AdminSafe",
+            address: "10.0.1.5",
+            platformId: "UnixSSH",
+            secretType: "password",
+            username: "root",
+          },
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText("Account Details")).toBeInTheDocument();
+    // "root-account" appears in heading + DetailRow
+    const accountTexts = screen.getAllByText("root-account");
+    expect(accountTexts.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("acc-1")).toBeInTheDocument();
+    expect(screen.getByText("AdminSafe")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.5")).toBeInTheDocument();
+    expect(screen.getByText("UnixSSH")).toBeInTheDocument();
+  });
+
+  it("renders EC2 loading state for ec2-target type", () => {
+    mockEC2Loading = true;
+    const { container } = render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-ec2-target",
+          nodeData: { instanceId: "i-123" },
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(
+      container.querySelector(".animate-spin") ||
+        screen.getByText("Loading instance details..."),
+    ).toBeTruthy();
+  });
+
+  it("renders EC2 not found when instance is null", () => {
+    mockEC2Instance = null;
+    mockEC2Loading = false;
+    render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-ec2-target",
+          nodeData: { instanceId: "i-123" },
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText(/Instance not found/)).toBeInTheDocument();
+  });
+
+  it("renders RDS loading state", () => {
+    mockRDSLoading = true;
+    render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-rds-target",
+          nodeData: { dbIdentifier: "mydb" },
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText("Loading database details...")).toBeInTheDocument();
+  });
+
+  it("renders RDS not found when instance is null", () => {
+    mockRDSInstance = null;
+    mockRDSLoading = false;
+    render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-rds-target",
+          nodeData: { dbIdentifier: "mydb" },
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText(/Database not found/)).toBeInTheDocument();
+  });
+
+  it("returns null for unknown node type", () => {
+    const { container } = render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "unknown",
+          nodeData: {},
+        }}
+        onClose={onClose}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders terraform section for tf-managed account", () => {
+    render(
+      <AccessMappingDetailPanel
+        selectedNode={{
+          nodeType: "access-account",
+          nodeData: {
+            accountName: "tf-account",
+            tfManaged: true,
+            tfStateSource: "s3://bucket/state",
+            tfResourceAddress: "cyberark_account.x",
+          },
+        }}
+        onClose={onClose}
+      />,
+    );
+    // "Terraform" appears in the section header and TerraformBadge
+    const tfTexts = screen.getAllByText(/Terraform/i);
+    expect(tfTexts.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/access-mapping/AccessMappingFilterBar.test.tsx
+++ b/frontend/src/components/access-mapping/AccessMappingFilterBar.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { AccessMappingFilterBar } from "./AccessMappingFilterBar";
+import type { AccessMappingFilters } from "./AccessMappingFilterBar";
+
+describe("AccessMappingFilterBar", () => {
+  const defaultFilters: AccessMappingFilters = {
+    search: "",
+    accessType: "",
+    selectedUser: "",
+  };
+
+  const onChange = vi.fn();
+  const users = ["john", "jane", "bob"];
+
+  it("renders search input", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={true}
+      />,
+    );
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+  });
+
+  it("renders access type selector", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    expect(screen.getByText("All Access Types")).toBeInTheDocument();
+  });
+
+  it("renders user selector for admin", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={true}
+      />,
+    );
+    expect(screen.getByText("All Users")).toBeInTheDocument();
+    expect(screen.getByText("john")).toBeInTheDocument();
+    expect(screen.getByText("jane")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
+  it("hides user selector for non-admin", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    expect(screen.queryByText("All Users")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange on search input", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "test" } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...defaultFilters,
+      search: "test",
+    });
+  });
+
+  it("shows clear button when filters active", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={{ ...defaultFilters, search: "test" }}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    const clearButton = screen.getByTitle("Clear filters");
+    expect(clearButton).toBeInTheDocument();
+  });
+
+  it("hides clear button when no filters", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={defaultFilters}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    expect(screen.queryByTitle("Clear filters")).not.toBeInTheDocument();
+  });
+
+  it("clear button resets all filters", () => {
+    render(
+      <AccessMappingFilterBar
+        filters={{ search: "test", accessType: "standing", selectedUser: "" }}
+        onChange={onChange}
+        users={users}
+        isAdmin={false}
+      />,
+    );
+    fireEvent.click(screen.getByTitle("Clear filters"));
+    expect(onChange).toHaveBeenCalledWith({
+      search: "",
+      accessType: "",
+      selectedUser: "",
+    });
+  });
+});

--- a/frontend/src/components/access-mapping/AccessMappingLegend.test.tsx
+++ b/frontend/src/components/access-mapping/AccessMappingLegend.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { AccessMappingLegend } from "./AccessMappingLegend";
+
+describe("AccessMappingLegend", () => {
+  const stats = {
+    total_users: 5,
+    total_targets: 10,
+    total_standing_paths: 8,
+    total_jit_paths: 3,
+  };
+
+  it("renders stats when provided", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders stat labels", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    expect(screen.getByText("Users")).toBeInTheDocument();
+    expect(screen.getByText("Targets")).toBeInTheDocument();
+    expect(screen.getByText("Standing")).toBeInTheDocument();
+    expect(screen.getByText("JIT")).toBeInTheDocument();
+  });
+
+  it("does not render stats when null", () => {
+    render(<AccessMappingLegend stats={null} />);
+    expect(screen.queryByText("Users")).not.toBeInTheDocument();
+    expect(screen.queryByText("Targets")).not.toBeInTheDocument();
+  });
+
+  it("renders Legend toggle button", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    expect(screen.getByText("Legend")).toBeInTheDocument();
+  });
+
+  it("legend content hidden by default", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    expect(screen.queryByText("Nodes")).not.toBeInTheDocument();
+  });
+
+  it("expands legend on click", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    fireEvent.click(screen.getByText("Legend"));
+    expect(screen.getByText("Nodes")).toBeInTheDocument();
+    expect(screen.getByText("Connections")).toBeInTheDocument();
+  });
+
+  it("shows node type labels when expanded", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    fireEvent.click(screen.getByText("Legend"));
+    expect(screen.getByText("User")).toBeInTheDocument();
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    expect(screen.getByText("Safe")).toBeInTheDocument();
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.getByText("SIA Policy")).toBeInTheDocument();
+    expect(screen.getByText("EC2 Target")).toBeInTheDocument();
+    expect(screen.getByText("RDS Target")).toBeInTheDocument();
+  });
+
+  it("shows connection types when expanded", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    fireEvent.click(screen.getByText("Legend"));
+    expect(screen.getByText("Standing Access")).toBeInTheDocument();
+    expect(screen.getByText("JIT Access")).toBeInTheDocument();
+  });
+
+  it("collapses legend on second click", () => {
+    render(<AccessMappingLegend stats={stats} />);
+    fireEvent.click(screen.getByText("Legend"));
+    expect(screen.getByText("Nodes")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Legend"));
+    expect(screen.queryByText("Nodes")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cyberark/CyberArkTabNavigation.test.tsx
+++ b/frontend/src/components/cyberark/CyberArkTabNavigation.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { CyberArkTabNavigation } from "./CyberArkTabNavigation";
+
+describe("CyberArkTabNavigation", () => {
+  it("renders all four tabs", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="safes" onTabChange={onChange} />);
+    expect(screen.getByText("Safes")).toBeInTheDocument();
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+    expect(screen.getByText("Users")).toBeInTheDocument();
+    expect(screen.getByText("SIA Policies")).toBeInTheDocument();
+  });
+
+  it("calls onTabChange when tab clicked", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="safes" onTabChange={onChange} />);
+    fireEvent.click(screen.getByText("Roles"));
+    expect(onChange).toHaveBeenCalledWith("roles");
+  });
+
+  it("calls onTabChange with users", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="safes" onTabChange={onChange} />);
+    fireEvent.click(screen.getByText("Users"));
+    expect(onChange).toHaveBeenCalledWith("users");
+  });
+
+  it("calls onTabChange with sia-policies", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="safes" onTabChange={onChange} />);
+    fireEvent.click(screen.getByText("SIA Policies"));
+    expect(onChange).toHaveBeenCalledWith("sia-policies");
+  });
+
+  it("highlights active tab with blue styling", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="roles" onTabChange={onChange} />);
+    const rolesButton = screen.getByText("Roles").closest("button")!;
+    expect(rolesButton.className).toContain("border-blue-500");
+  });
+
+  it("non-active tabs have transparent border", () => {
+    const onChange = vi.fn();
+    render(<CyberArkTabNavigation activeTab="safes" onTabChange={onChange} />);
+    const rolesButton = screen.getByText("Roles").closest("button")!;
+    expect(rolesButton.className).toContain("border-transparent");
+  });
+});

--- a/frontend/src/components/cyberark/RoleDetailPanel.test.tsx
+++ b/frontend/src/components/cyberark/RoleDetailPanel.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { RoleDetailPanel } from "./RoleDetailPanel";
+
+// =============================================================================
+// Mock hooks
+// =============================================================================
+
+let mockRole: Record<string, unknown> | null = null;
+let mockIsLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkRole: () => ({
+    data: mockRole,
+    isLoading: mockIsLoading,
+  }),
+}));
+
+describe("RoleDetailPanel", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockRole = {
+      role_id: "role-1",
+      role_name: "Admin",
+      description: "Administrator role",
+      tf_managed: true,
+      tf_state_source: "s3://bucket/state.tfstate",
+      tf_resource_address: "cyberark_role.admin",
+      updated_at: "2024-01-15T12:00:00Z",
+      created_at: "2024-01-01T00:00:00Z",
+      members: [{ id: 1, member_name: "john@corp.com", member_type: "user" }],
+    };
+  });
+
+  it("renders Role Details heading", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    expect(screen.getByText("Role Details")).toBeInTheDocument();
+  });
+
+  it("renders role name", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    // Role name appears in heading and DetailRow
+    const matches = screen.getAllByText("Admin");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders basic info section", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    expect(screen.getByText("Basic Info")).toBeInTheDocument();
+    expect(screen.getByText("role-1")).toBeInTheDocument();
+    expect(screen.getByText("Administrator role")).toBeInTheDocument();
+  });
+
+  it("renders members table", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    expect(screen.getByText("Members (1)")).toBeInTheDocument();
+    expect(screen.getByText("john@corp.com")).toBeInTheDocument();
+  });
+
+  it("renders terraform section when tf_managed", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+  });
+
+  it("renders timestamps", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    expect(screen.getByText("Timestamps")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner", () => {
+    mockIsLoading = true;
+    mockRole = null;
+    const { container } = render(
+      <RoleDetailPanel roleId="role-1" onClose={onClose} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows not found message when role is null", () => {
+    mockRole = null;
+    render(<RoleDetailPanel roleId="unknown" onClose={onClose} />);
+    expect(screen.getByText("Role not found.")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    render(<RoleDetailPanel roleId="role-1" onClose={onClose} />);
+    const closeButtons = screen.getAllByRole("button");
+    fireEvent.click(closeButtons[0]);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/cyberark/RoleList.test.tsx
+++ b/frontend/src/components/cyberark/RoleList.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { RoleList } from "./RoleList";
+import type { CyberArkRole } from "@/types";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockRole1: CyberArkRole = {
+  id: 1,
+  role_id: "role-1",
+  role_name: "Admin",
+  description: "Administrator role",
+  tf_managed: true,
+  tf_state_source: "s3://bucket/state.tfstate",
+  tf_resource_address: "cyberark_role.admin",
+  is_deleted: false,
+  updated_at: "2024-01-15T12:00:00Z",
+};
+
+const mockRole2: CyberArkRole = {
+  id: 2,
+  role_id: "role-2",
+  role_name: "Viewer",
+  description: null,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  is_deleted: false,
+  updated_at: "2024-01-14T12:00:00Z",
+};
+
+let mockData: {
+  data: CyberArkRole[];
+  meta: { total: number; last_refreshed: string | null };
+} | null = {
+  data: [mockRole1, mockRole2],
+  meta: { total: 2, last_refreshed: null },
+};
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkRoles: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+  useCyberArkRole: () => ({
+    data: null,
+    isLoading: false,
+  }),
+}));
+
+describe("RoleList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = {
+      data: [mockRole1, mockRole2],
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders roles count", () => {
+    render(<RoleList />);
+    expect(screen.getByText("2 roles found")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<RoleList />);
+    expect(screen.getByPlaceholderText("Search roles...")).toBeInTheDocument();
+  });
+
+  it("renders role names in table", () => {
+    render(<RoleList />);
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Viewer")).toBeInTheDocument();
+  });
+
+  it("renders role IDs", () => {
+    render(<RoleList />);
+    expect(screen.getByText("role-1")).toBeInTheDocument();
+    expect(screen.getByText("role-2")).toBeInTheDocument();
+  });
+
+  it("renders description or dash for null", () => {
+    render(<RoleList />);
+    expect(screen.getByText("Administrator role")).toBeInTheDocument();
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("renders table headers", () => {
+    render(<RoleList />);
+    expect(screen.getByText("Role Name")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<RoleList />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    mockError = new Error("Failed");
+    mockData = null;
+    render(<RoleList />);
+    expect(screen.getByText("Error loading roles")).toBeInTheDocument();
+  });
+
+  it("shows empty state", () => {
+    mockData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<RoleList />);
+    expect(screen.getByText("No roles found")).toBeInTheDocument();
+  });
+
+  it("renders terraform filter dropdown", () => {
+    render(<RoleList />);
+    expect(screen.getByText("All resources")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cyberark/SIAPolicyDetailPanel.test.tsx
+++ b/frontend/src/components/cyberark/SIAPolicyDetailPanel.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { SIAPolicyDetailPanel } from "./SIAPolicyDetailPanel";
+
+// =============================================================================
+// Mock hooks
+// =============================================================================
+
+let mockPolicy: Record<string, unknown> | null = null;
+let mockIsLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkSIAPolicy: () => ({
+    data: mockPolicy,
+    isLoading: mockIsLoading,
+  }),
+}));
+
+describe("SIAPolicyDetailPanel", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockPolicy = {
+      policy_id: "pol-1",
+      policy_name: "VMAccess",
+      policy_type: "vm",
+      description: "VM access policy",
+      status: "active",
+      tf_managed: true,
+      tf_state_source: "s3://bucket/state.tfstate",
+      tf_resource_address: "cyberark_sia_policy.vm",
+      updated_at: "2024-01-15T12:00:00Z",
+      created_at: "2024-01-01T00:00:00Z",
+      target_criteria: { regions: ["us-east-1"], tags: { env: ["prod"] } },
+      principals: [
+        {
+          id: 1,
+          principal_name: "admin@corp.com",
+          principal_type: "user",
+        },
+      ],
+    };
+  });
+
+  it("renders SIA Policy Details heading", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("SIA Policy Details")).toBeInTheDocument();
+  });
+
+  it("renders policy name", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    // Policy name appears in heading and DetailRow
+    const matches = screen.getAllByText("VMAccess");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders VM type badge", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("VM")).toBeInTheDocument();
+  });
+
+  it("renders Database type badge for database policies", () => {
+    mockPolicy = {
+      ...mockPolicy,
+      policy_type: "database",
+      principals: [],
+      target_criteria: null,
+    };
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("Database")).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    // "active" appears in the badge
+    const activeTexts = screen.getAllByText("active");
+    expect(activeTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders basic info section", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("Basic Info")).toBeInTheDocument();
+    expect(screen.getByText("pol-1")).toBeInTheDocument();
+    expect(screen.getByText("VM access policy")).toBeInTheDocument();
+  });
+
+  it("renders target criteria section", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("Target Criteria")).toBeInTheDocument();
+    expect(screen.getByText("us-east-1")).toBeInTheDocument();
+    expect(screen.getByText("env: prod")).toBeInTheDocument();
+  });
+
+  it("renders principals table", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("Principals (1)")).toBeInTheDocument();
+    expect(screen.getByText("admin@corp.com")).toBeInTheDocument();
+  });
+
+  it("renders terraform section when tf_managed", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    // "Terraform" appears in the section header
+    const tfTexts = screen.getAllByText("Terraform");
+    expect(tfTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders timestamps", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    expect(screen.getByText("Timestamps")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner", () => {
+    mockIsLoading = true;
+    mockPolicy = null;
+    const { container } = render(
+      <SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows not found message when policy is null", () => {
+    mockPolicy = null;
+    render(<SIAPolicyDetailPanel policyId="unknown" onClose={onClose} />);
+    expect(screen.getByText("Policy not found.")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    render(<SIAPolicyDetailPanel policyId="pol-1" onClose={onClose} />);
+    const closeButtons = screen.getAllByRole("button");
+    fireEvent.click(closeButtons[0]);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/cyberark/SIAPolicyList.test.tsx
+++ b/frontend/src/components/cyberark/SIAPolicyList.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SIAPolicyList } from "./SIAPolicyList";
+import type { CyberArkSIAPolicy } from "@/types";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockPolicy1: CyberArkSIAPolicy = {
+  id: 1,
+  policy_id: "pol-1",
+  policy_name: "VMAccess",
+  policy_type: "vm",
+  description: "VM access policy",
+  status: "active",
+  target_criteria: null,
+  tf_managed: true,
+  tf_state_source: "s3://bucket/state.tfstate",
+  tf_resource_address: "cyberark_sia_policy.vm",
+  is_deleted: false,
+  updated_at: "2024-01-15T12:00:00Z",
+};
+
+const mockPolicy2: CyberArkSIAPolicy = {
+  id: 2,
+  policy_id: "pol-2",
+  policy_name: "DBAccess",
+  policy_type: "database",
+  description: null,
+  status: "inactive",
+  target_criteria: null,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  is_deleted: false,
+  updated_at: "2024-01-14T12:00:00Z",
+};
+
+let mockData: {
+  data: CyberArkSIAPolicy[];
+  meta: { total: number; last_refreshed: string | null };
+} | null = {
+  data: [mockPolicy1, mockPolicy2],
+  meta: { total: 2, last_refreshed: null },
+};
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkSIAPolicies: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+  useCyberArkSIAPolicy: () => ({
+    data: null,
+    isLoading: false,
+  }),
+}));
+
+describe("SIAPolicyList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = {
+      data: [mockPolicy1, mockPolicy2],
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders policies count", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("2 policies found")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<SIAPolicyList />);
+    expect(
+      screen.getByPlaceholderText("Search policies..."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders policy names in table", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("VMAccess")).toBeInTheDocument();
+    expect(screen.getByText("DBAccess")).toBeInTheDocument();
+  });
+
+  it("renders policy IDs", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("pol-1")).toBeInTheDocument();
+    expect(screen.getByText("pol-2")).toBeInTheDocument();
+  });
+
+  it("renders VM type badge", () => {
+    render(<SIAPolicyList />);
+    // "VM" appears in both the type filter option and the table cell
+    const vmTexts = screen.getAllByText("VM");
+    expect(vmTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders Database type badge", () => {
+    render(<SIAPolicyList />);
+    // "Database" appears in both the type filter option and the table cell
+    const dbTexts = screen.getAllByText("Database");
+    expect(dbTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders status badges", () => {
+    render(<SIAPolicyList />);
+    // "active" and "inactive" appear in both filter options and table
+    const activeTexts = screen.getAllByText("active");
+    expect(activeTexts.length).toBeGreaterThanOrEqual(1);
+    const inactiveTexts = screen.getAllByText("inactive");
+    expect(inactiveTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders description or dash", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("VM access policy")).toBeInTheDocument();
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("renders table headers", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("Policy Name")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+  });
+
+  it("renders filter dropdowns", () => {
+    render(<SIAPolicyList />);
+    expect(screen.getByText("All types")).toBeInTheDocument();
+    expect(screen.getByText("All statuses")).toBeInTheDocument();
+    expect(screen.getByText("All resources")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<SIAPolicyList />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    mockError = new Error("Failed");
+    mockData = null;
+    render(<SIAPolicyList />);
+    expect(screen.getByText("Error loading SIA policies")).toBeInTheDocument();
+  });
+
+  it("shows empty state", () => {
+    mockData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<SIAPolicyList />);
+    expect(screen.getByText("No SIA policies found")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cyberark/SafeDetailPanel.test.tsx
+++ b/frontend/src/components/cyberark/SafeDetailPanel.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { SafeDetailPanel } from "./SafeDetailPanel";
+
+// =============================================================================
+// Mock hooks
+// =============================================================================
+
+let mockSafe: Record<string, unknown> | null = null;
+let mockIsLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkSafe: () => ({
+    data: mockSafe,
+    isLoading: mockIsLoading,
+  }),
+}));
+
+describe("SafeDetailPanel", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockSafe = {
+      safe_name: "AdminSafe",
+      description: "Admin safe",
+      number_of_members: 3,
+      number_of_accounts: 5,
+      tf_managed: true,
+      tf_state_source: "s3://bucket/state.tfstate",
+      tf_resource_address: "cyberark_safe.admin",
+      updated_at: "2024-01-15T12:00:00Z",
+      created_at: "2024-01-01T00:00:00Z",
+      members: [
+        {
+          id: 1,
+          member_name: "admin@corp.com",
+          member_type: "user",
+          permission_level: "Full",
+        },
+      ],
+      accounts: [
+        {
+          account_id: "acc-1",
+          account_name: "root-account",
+          address: "10.0.1.5",
+          platform_id: "UnixSSH",
+        },
+      ],
+    };
+  });
+
+  it("renders Safe Details heading", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Safe Details")).toBeInTheDocument();
+  });
+
+  it("renders safe name", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    // Safe name appears in heading and DetailRow
+    const matches = screen.getAllByText("AdminSafe");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders basic info section", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Basic Info")).toBeInTheDocument();
+    expect(screen.getByText("Admin safe")).toBeInTheDocument();
+  });
+
+  it("renders member count in detail row", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders members table", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Members (1)")).toBeInTheDocument();
+    expect(screen.getByText("admin@corp.com")).toBeInTheDocument();
+    expect(screen.getByText("Full")).toBeInTheDocument();
+  });
+
+  it("renders accounts table", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Accounts (1)")).toBeInTheDocument();
+    expect(screen.getByText("root-account")).toBeInTheDocument();
+    expect(screen.getByText("10.0.1.5")).toBeInTheDocument();
+    expect(screen.getByText("UnixSSH")).toBeInTheDocument();
+  });
+
+  it("renders terraform section when tf_managed", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+    expect(screen.getByText("s3://bucket/state.tfstate")).toBeInTheDocument();
+  });
+
+  it("renders timestamps section", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    expect(screen.getByText("Timestamps")).toBeInTheDocument();
+    expect(screen.getByText("Last Updated")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner", () => {
+    mockIsLoading = true;
+    mockSafe = null;
+    const { container } = render(
+      <SafeDetailPanel safeName="AdminSafe" onClose={onClose} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows not found message when safe is null", () => {
+    mockSafe = null;
+    render(<SafeDetailPanel safeName="Unknown" onClose={onClose} />);
+    expect(screen.getByText("Safe not found.")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    render(<SafeDetailPanel safeName="AdminSafe" onClose={onClose} />);
+    const closeButtons = screen.getAllByRole("button");
+    fireEvent.click(closeButtons[0]);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/cyberark/SafeList.test.tsx
+++ b/frontend/src/components/cyberark/SafeList.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SafeList } from "./SafeList";
+import type { CyberArkSafe } from "@/types";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockSafe1: CyberArkSafe = {
+  id: 1,
+  safe_name: "AdminSafe",
+  description: "Admin safe for privileged accounts",
+  managing_cpm: "PasswordManager",
+  number_of_members: 5,
+  number_of_accounts: 10,
+  tf_managed: true,
+  tf_state_source: "s3://bucket/state.tfstate",
+  tf_resource_address: "cyberark_safe.admin",
+  is_deleted: false,
+  updated_at: "2024-01-15T12:00:00Z",
+};
+
+const mockSafe2: CyberArkSafe = {
+  id: 2,
+  safe_name: "AppSafe",
+  description: null,
+  managing_cpm: null,
+  number_of_members: 3,
+  number_of_accounts: 8,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  is_deleted: false,
+  updated_at: "2024-01-14T12:00:00Z",
+};
+
+let mockData: {
+  data: CyberArkSafe[];
+  meta: { total: number; last_refreshed: string | null };
+} | null = {
+  data: [mockSafe1, mockSafe2],
+  meta: { total: 2, last_refreshed: null },
+};
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkSafes: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+  useCyberArkSafe: () => ({
+    data: null,
+    isLoading: false,
+  }),
+}));
+
+describe("SafeList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = {
+      data: [mockSafe1, mockSafe2],
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders safes count", () => {
+    render(<SafeList />);
+    expect(screen.getByText("2 safes found")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<SafeList />);
+    expect(screen.getByPlaceholderText("Search safes...")).toBeInTheDocument();
+  });
+
+  it("renders terraform filter dropdown", () => {
+    render(<SafeList />);
+    expect(screen.getByText("All resources")).toBeInTheDocument();
+  });
+
+  it("renders safe names in table", () => {
+    render(<SafeList />);
+    expect(screen.getByText("AdminSafe")).toBeInTheDocument();
+    expect(screen.getByText("AppSafe")).toBeInTheDocument();
+  });
+
+  it("renders safe description when present", () => {
+    render(<SafeList />);
+    expect(
+      screen.getByText("Admin safe for privileged accounts"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders member counts", () => {
+    render(<SafeList />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders account counts", () => {
+    render(<SafeList />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    render(<SafeList />);
+    expect(screen.getByText("Safe Name")).toBeInTheDocument();
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("Accounts")).toBeInTheDocument();
+    expect(screen.getByText("Terraform")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<SafeList />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    mockError = new Error("Failed");
+    mockData = null;
+    render(<SafeList />);
+    expect(screen.getByText("Error loading safes")).toBeInTheDocument();
+  });
+
+  it("shows empty state", () => {
+    mockData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<SafeList />);
+    expect(screen.getByText("No safes found")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cyberark/UserList.test.tsx
+++ b/frontend/src/components/cyberark/UserList.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { UserList } from "./UserList";
+import type { CyberArkIdentityUser } from "@/types";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockUser1: CyberArkIdentityUser = {
+  id: 1,
+  user_id: "u1",
+  user_name: "john.doe",
+  display_name: "John Doe",
+  email: "john@example.com",
+  active: true,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  is_deleted: false,
+  updated_at: "2024-01-15T12:00:00Z",
+};
+
+const mockUser2: CyberArkIdentityUser = {
+  id: 2,
+  user_id: "u2",
+  user_name: "jane.smith",
+  display_name: null,
+  email: null,
+  active: false,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  is_deleted: false,
+  updated_at: "2024-01-14T12:00:00Z",
+};
+
+let mockData: {
+  data: CyberArkIdentityUser[];
+  meta: { total: number; last_refreshed: string | null };
+} | null = {
+  data: [mockUser1, mockUser2],
+  meta: { total: 2, last_refreshed: null },
+};
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkUsers: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+}));
+
+describe("UserList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = {
+      data: [mockUser1, mockUser2],
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders users count", () => {
+    render(<UserList />);
+    expect(screen.getByText("2 users found")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<UserList />);
+    expect(screen.getByPlaceholderText("Search users...")).toBeInTheDocument();
+  });
+
+  it("renders user names in table", () => {
+    render(<UserList />);
+    expect(screen.getByText("john.doe")).toBeInTheDocument();
+    expect(screen.getByText("jane.smith")).toBeInTheDocument();
+  });
+
+  it("renders user IDs", () => {
+    render(<UserList />);
+    expect(screen.getByText("u1")).toBeInTheDocument();
+    expect(screen.getByText("u2")).toBeInTheDocument();
+  });
+
+  it("renders display name or dash", () => {
+    render(<UserList />);
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("renders email or dash", () => {
+    render(<UserList />);
+    expect(screen.getByText("john@example.com")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    render(<UserList />);
+    expect(screen.getByText("Username")).toBeInTheDocument();
+    expect(screen.getByText("Display Name")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("renders status filter dropdown", () => {
+    render(<UserList />);
+    expect(screen.getByText("All statuses")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<UserList />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    mockError = new Error("Failed");
+    mockData = null;
+    render(<UserList />);
+    expect(screen.getByText("Error loading users")).toBeInTheDocument();
+  });
+
+  it("shows empty state", () => {
+    mockData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<UserList />);
+    expect(screen.getByText("No users found")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/settings/CyberArkSettings.test.tsx
+++ b/frontend/src/components/settings/CyberArkSettings.test.tsx
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CyberArkSettings } from "./CyberArkSettings";
+
+// =============================================================================
+// Mock API functions
+// =============================================================================
+
+const mockGetCyberArkSettings = vi.fn();
+const mockUpdateCyberArkSettings = vi.fn();
+const mockTestCyberArkConnection = vi.fn();
+const mockGetCyberArkSyncStatus = vi.fn();
+const mockDiscoverCyberArkTenant = vi.fn();
+const mockGetScimSettings = vi.fn();
+const mockUpdateScimSettings = vi.fn();
+const mockTestScimConnection = vi.fn();
+
+vi.mock("@/api/client", () => ({
+  getCyberArkSettings: (...args: unknown[]) => mockGetCyberArkSettings(...args),
+  updateCyberArkSettings: (...args: unknown[]) =>
+    mockUpdateCyberArkSettings(...args),
+  testCyberArkConnection: (...args: unknown[]) =>
+    mockTestCyberArkConnection(...args),
+  getCyberArkSyncStatus: (...args: unknown[]) =>
+    mockGetCyberArkSyncStatus(...args),
+  discoverCyberArkTenant: (...args: unknown[]) =>
+    mockDiscoverCyberArkTenant(...args),
+  getScimSettings: (...args: unknown[]) => mockGetScimSettings(...args),
+  updateScimSettings: (...args: unknown[]) => mockUpdateScimSettings(...args),
+  testScimConnection: (...args: unknown[]) => mockTestScimConnection(...args),
+}));
+
+// =============================================================================
+// Default responses
+// =============================================================================
+
+const defaultSettings = {
+  enabled: true,
+  tenant_name: "papaya",
+  base_url: "https://papaya.privilegecloud.cyberark.cloud",
+  identity_url: "https://abc1234.id.cyberark.cloud",
+  uap_base_url: "https://papaya.uap.cyberark.cloud/api",
+  client_id: "svc-account",
+  has_client_secret: true,
+  updated_at: "2024-01-15T12:00:00Z",
+  updated_by: "admin",
+};
+
+const defaultScimSettings = {
+  scim_enabled: true,
+  scim_app_id: "labvisscim",
+  scim_scope: "scim:read",
+  scim_client_id: "scim-client",
+  has_scim_client_secret: true,
+};
+
+const defaultSyncStatus = {
+  config: {
+    source: "api",
+    enabled: true,
+    db_settings_exists: true,
+    db_enabled: true,
+    all_fields_set: true,
+  },
+  database_counts: {
+    roles_total: 5,
+    roles_active: 4,
+    safes: 10,
+    accounts: 20,
+    sia_policies: 3,
+    users: 15,
+  },
+  last_sync: {
+    synced_at: "2024-01-15T12:00:00Z",
+    status: "success",
+    resource_count: 53,
+  },
+};
+
+describe("CyberArkSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCyberArkSettings.mockResolvedValue(defaultSettings);
+    mockGetScimSettings.mockResolvedValue(defaultScimSettings);
+    mockGetCyberArkSyncStatus.mockResolvedValue(defaultSyncStatus);
+  });
+
+  it("shows loading spinner on mount", () => {
+    // Make settings hang
+    mockGetCyberArkSettings.mockImplementation(() => new Promise(() => {}));
+    const { container } = render(<CyberArkSettings />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("renders CyberArk Integration after load", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("CyberArk Integration")).toBeInTheDocument();
+    });
+  });
+
+  it("pre-fills tenant name and URLs", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("papaya")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByDisplayValue("https://papaya.privilegecloud.cyberark.cloud"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("https://abc1234.id.cyberark.cloud"),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("svc-account")).toBeInTheDocument();
+  });
+
+  it("shows secret placeholder when secret exists", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("CyberArk Integration")).toBeInTheDocument();
+    });
+    // The password field should have placeholder "••••••••"
+    const secretInputs = screen.getAllByPlaceholderText("••••••••");
+    expect(secretInputs.length).toBeGreaterThan(0);
+  });
+
+  it("shows Secret saved hint when has_client_secret is true", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      // Both platform and SCIM have this hint
+      const hints = screen.getAllByText("Secret saved. Leave blank to keep.");
+      expect(hints.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("enable toggle reflects state", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Enable CyberArk")).toBeInTheDocument();
+    });
+  });
+
+  it("calls discoverCyberArkTenant on Lookup click", async () => {
+    mockDiscoverCyberArkTenant.mockResolvedValueOnce({
+      success: true,
+      base_url: "https://discovered.privilegecloud.cyberark.cloud",
+      identity_url: "https://discovered.id.cyberark.cloud",
+      uap_base_url: "https://discovered.uap.cyberark.cloud/api",
+      region: "us-east",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Lookup")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Lookup"));
+    await waitFor(() => {
+      expect(mockDiscoverCyberArkTenant).toHaveBeenCalledWith({
+        subdomain: "papaya",
+      });
+    });
+  });
+
+  it("shows discovered region on success", async () => {
+    mockDiscoverCyberArkTenant.mockResolvedValueOnce({
+      success: true,
+      base_url: "https://x.privilegecloud.cyberark.cloud",
+      identity_url: "https://x.id.cyberark.cloud",
+      uap_base_url: "",
+      region: "us-east",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Lookup")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Lookup"));
+    await waitFor(() => {
+      expect(
+        screen.getByText("Discovered (region: us-east)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on discovery failure", async () => {
+    mockDiscoverCyberArkTenant.mockResolvedValueOnce({
+      success: false,
+      message: "Tenant not found",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Lookup")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Lookup"));
+    await waitFor(() => {
+      expect(screen.getByText("Tenant not found")).toBeInTheDocument();
+    });
+  });
+
+  it("calls testCyberArkConnection on Test Platform click", async () => {
+    mockTestCyberArkConnection.mockResolvedValueOnce({
+      success: true,
+      message: "Connection successful",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Test Platform")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Test Platform"));
+    await waitFor(() => {
+      expect(mockTestCyberArkConnection).toHaveBeenCalled();
+    });
+  });
+
+  it("shows green banner on test success", async () => {
+    mockTestCyberArkConnection.mockResolvedValueOnce({
+      success: true,
+      message: "Connection successful",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Test Platform")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Test Platform"));
+    await waitFor(() => {
+      expect(screen.getByText("Connection successful")).toBeInTheDocument();
+    });
+  });
+
+  it("shows red banner on test failure", async () => {
+    mockTestCyberArkConnection.mockResolvedValueOnce({
+      success: false,
+      message: "Auth failed",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Test Platform")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Test Platform"));
+    await waitFor(() => {
+      expect(screen.getByText("Auth failed")).toBeInTheDocument();
+    });
+  });
+
+  it("calls updateCyberArkSettings on Save", async () => {
+    mockUpdateCyberArkSettings.mockResolvedValueOnce(defaultSettings);
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Save Platform Settings")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save Platform Settings"));
+    await waitFor(() => {
+      expect(mockUpdateCyberArkSettings).toHaveBeenCalled();
+    });
+  });
+
+  it("shows Saved on successful save", async () => {
+    mockUpdateCyberArkSettings.mockResolvedValueOnce(defaultSettings);
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Save Platform Settings")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save Platform Settings"));
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on save failure", async () => {
+    mockUpdateCyberArkSettings.mockRejectedValueOnce({
+      response: { data: { detail: "Invalid config" } },
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Save Platform Settings")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save Platform Settings"));
+    await waitFor(() => {
+      expect(screen.getByText("Invalid config")).toBeInTheDocument();
+    });
+  });
+
+  it("renders SCIM Integration section", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("SCIM Integration")).toBeInTheDocument();
+    });
+  });
+
+  it("renders SCIM fields", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("SCIM App ID")).toBeInTheDocument();
+      expect(screen.getByText("Scope")).toBeInTheDocument();
+      expect(screen.getByText("SCIM Client ID")).toBeInTheDocument();
+      expect(screen.getByText("SCIM Client Secret")).toBeInTheDocument();
+    });
+  });
+
+  it("calls testScimConnection on Test SCIM click", async () => {
+    mockTestScimConnection.mockResolvedValueOnce({
+      success: true,
+      message: "SCIM OK",
+    });
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Test SCIM")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Test SCIM"));
+    await waitFor(() => {
+      expect(mockTestScimConnection).toHaveBeenCalled();
+    });
+  });
+
+  it("calls updateScimSettings on Save SCIM click", async () => {
+    mockUpdateScimSettings.mockResolvedValueOnce(defaultScimSettings);
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Save SCIM Settings")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save SCIM Settings"));
+    await waitFor(() => {
+      expect(mockUpdateScimSettings).toHaveBeenCalled();
+    });
+  });
+
+  it("renders Sync Status panel", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Sync Status")).toBeInTheDocument();
+    });
+  });
+
+  it("expands Sync Status panel to show resource counts", async () => {
+    render(<CyberArkSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Sync Status")).toBeInTheDocument();
+    });
+    // Click the Sync Status button to expand
+    const syncButton = screen.getByText("Sync Status").closest("button")!;
+    fireEvent.click(syncButton);
+    await waitFor(() => {
+      expect(screen.getByText("Roles")).toBeInTheDocument();
+      expect(screen.getByText("Safes")).toBeInTheDocument();
+      expect(screen.getByText("Accounts")).toBeInTheDocument();
+      expect(screen.getByText("SIA Policies")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/topology/utils/layoutCalculator.test.ts
+++ b/frontend/src/components/topology/utils/layoutCalculator.test.ts
@@ -1,0 +1,659 @@
+import { describe, it, expect } from "vitest";
+import { calculateTopologyLayout, createEdges } from "./layoutCalculator";
+import type {
+  TopologyResponse,
+  TopologyVPC,
+  TopologySubnet,
+} from "@/types/topology";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeSubnet(overrides: Partial<TopologySubnet> = {}): TopologySubnet {
+  return {
+    id: "subnet-1",
+    name: "Test Subnet",
+    cidr_block: "10.0.1.0/24",
+    availability_zone: "us-east-1a",
+    subnet_type: "public",
+    display_status: "active",
+    tf_managed: false,
+    tf_resource_address: null,
+    nat_gateway: null,
+    ec2_instances: [],
+    rds_instances: [],
+    ecs_containers: [],
+    ...overrides,
+  };
+}
+
+function makeVPC(overrides: Partial<TopologyVPC> = {}): TopologyVPC {
+  return {
+    id: "vpc-1",
+    name: "Test VPC",
+    cidr_block: "10.0.0.0/16",
+    state: "available",
+    display_status: "active",
+    tf_managed: false,
+    tf_resource_address: null,
+    internet_gateway: null,
+    subnets: [],
+    elastic_ips: [],
+    ...overrides,
+  };
+}
+
+function makeResponse(vpcs: TopologyVPC[]): TopologyResponse {
+  return {
+    vpcs,
+    meta: {
+      total_vpcs: vpcs.length,
+      total_subnets: 0,
+      total_ec2: 0,
+      total_rds: 0,
+      total_ecs_containers: 0,
+      total_nat_gateways: 0,
+      total_internet_gateways: 0,
+      total_elastic_ips: 0,
+      last_refreshed: null,
+    },
+  };
+}
+
+// =============================================================================
+// calculateTopologyLayout
+// =============================================================================
+
+describe("calculateTopologyLayout", () => {
+  it("returns empty nodes and edges for empty VPC array", () => {
+    const result = calculateTopologyLayout(makeResponse([]));
+    expect(result.nodes).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  it("creates VPC node for a single VPC with no subnets", () => {
+    const result = calculateTopologyLayout(
+      makeResponse([makeVPC({ id: "vpc-1", name: "My VPC" })]),
+    );
+    const vpcNode = result.nodes.find((n) => n.id === "vpc-vpc-1");
+    expect(vpcNode).toBeDefined();
+    expect(vpcNode!.type).toBe("vpc");
+    expect(vpcNode!.data.label).toBe("My VPC");
+  });
+
+  it("creates IGW node as child of VPC when internet gateway present", () => {
+    const vpc = makeVPC({
+      internet_gateway: {
+        id: "igw-1",
+        name: "My IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: true,
+        tf_resource_address: "aws_internet_gateway.main",
+      },
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const igwNode = result.nodes.find((n) => n.id === "igw-igw-1");
+    expect(igwNode).toBeDefined();
+    expect(igwNode!.type).toBe("internet-gateway");
+    expect(igwNode!.parentNode).toBe("vpc-vpc-1");
+    expect(igwNode!.data.label).toBe("My IGW");
+  });
+
+  it("creates subnet and EC2 resource nodes", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          id: "sub-1",
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "web-server",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: "10.0.1.5",
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const subnetNode = result.nodes.find((n) => n.id === "subnet-sub-1");
+    const ec2Node = result.nodes.find((n) => n.id === "ec2-i-1");
+    expect(subnetNode).toBeDefined();
+    expect(ec2Node).toBeDefined();
+    expect(ec2Node!.parentNode).toBe("subnet-sub-1");
+    expect(ec2Node!.data.label).toBe("web-server");
+  });
+
+  it("places 2 EC2s in a 2-column grid layout", () => {
+    const ec2_1 = {
+      id: "i-1",
+      name: "ec2-a",
+      instance_type: "t3.micro",
+      state: "running",
+      display_status: "active" as const,
+      private_ip: null,
+      public_ip: null,
+      private_dns: null,
+      public_dns: null,
+      tf_managed: false,
+      tf_resource_address: null,
+    };
+    const ec2_2 = { ...ec2_1, id: "i-2", name: "ec2-b" };
+    const vpc = makeVPC({
+      subnets: [makeSubnet({ ec2_instances: [ec2_1, ec2_2] })],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const n1 = result.nodes.find((n) => n.id === "ec2-i-1");
+    const n2 = result.nodes.find((n) => n.id === "ec2-i-2");
+    expect(n1).toBeDefined();
+    expect(n2).toBeDefined();
+    // Both should be on the same row (row 0) with different x
+    expect(n1!.position.y).toBe(n2!.position.y);
+    expect(n1!.position.x).not.toBe(n2!.position.x);
+  });
+
+  it("wraps 3 EC2s to a second row", () => {
+    const mkEc2 = (id: string) => ({
+      id,
+      name: id,
+      instance_type: "t3.micro",
+      state: "running",
+      display_status: "active" as const,
+      private_ip: null,
+      public_ip: null,
+      private_dns: null,
+      public_dns: null,
+      tf_managed: false,
+      tf_resource_address: null,
+    });
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [mkEc2("i-1"), mkEc2("i-2"), mkEc2("i-3")],
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const n1 = result.nodes.find((n) => n.id === "ec2-i-1");
+    const n3 = result.nodes.find((n) => n.id === "ec2-i-3");
+    // Third node should be on a different row (higher y)
+    expect(n3!.position.y).toBeGreaterThan(n1!.position.y);
+  });
+
+  it("creates public and private subnets with correct y offsets", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({ id: "pub-1", subnet_type: "public" }),
+        makeSubnet({ id: "priv-1", subnet_type: "private" }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const pubNode = result.nodes.find((n) => n.id === "subnet-pub-1");
+    const privNode = result.nodes.find((n) => n.id === "subnet-priv-1");
+    expect(pubNode).toBeDefined();
+    expect(privNode).toBeDefined();
+    // Private subnet should be below public
+    expect(privNode!.position.y).toBeGreaterThan(pubNode!.position.y);
+  });
+
+  it("creates correct node types for mixed resources", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "ec2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+          rds_instances: [
+            {
+              id: "rds-1",
+              name: "db",
+              engine: "mysql",
+              instance_class: "db.t3.micro",
+              status: "available",
+              display_status: "active",
+              endpoint: null,
+              port: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+          ecs_containers: [
+            {
+              id: "ecs-1",
+              name: "task",
+              cluster_name: "prod",
+              launch_type: "FARGATE",
+              status: "RUNNING",
+              display_status: "active",
+              cpu: 256,
+              memory: 512,
+              image: null,
+              image_tag: null,
+              container_port: null,
+              private_ip: null,
+              tf_managed: false,
+              tf_resource_address: null,
+              managed_by: "unmanaged",
+            },
+          ],
+          nat_gateway: {
+            id: "nat-1",
+            name: "NAT",
+            state: "available",
+            display_status: "active",
+            primary_public_ip: null,
+            tf_managed: false,
+            tf_resource_address: null,
+          },
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    expect(result.nodes.find((n) => n.id === "ec2-i-1")?.type).toBe("ec2");
+    expect(result.nodes.find((n) => n.id === "rds-rds-1")?.type).toBe("rds");
+    expect(result.nodes.find((n) => n.id === "ecs-ecs-1")?.type).toBe(
+      "ecs-container",
+    );
+    expect(result.nodes.find((n) => n.id === "nat-nat-1")?.type).toBe(
+      "nat-gateway",
+    );
+  });
+
+  it("offsets second VPC by first VPC width + gap", () => {
+    const result = calculateTopologyLayout(
+      makeResponse([makeVPC({ id: "vpc-1" }), makeVPC({ id: "vpc-2" })]),
+    );
+    const v1 = result.nodes.find((n) => n.id === "vpc-vpc-1");
+    const v2 = result.nodes.find((n) => n.id === "vpc-vpc-2");
+    expect(v2!.position.x).toBeGreaterThan(v1!.position.x);
+  });
+
+  it("hides children when VPC is collapsed", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "ec2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const collapsed = new Set(["vpc-vpc-1"]);
+    const result = calculateTopologyLayout(makeResponse([vpc]), collapsed);
+    const vpcNode = result.nodes.find((n) => n.id === "vpc-vpc-1");
+    const subnetNode = result.nodes.find((n) => n.id === "subnet-subnet-1");
+    const ec2Node = result.nodes.find((n) => n.id === "ec2-i-1");
+    expect(vpcNode!.data).toHaveProperty("collapsed", true);
+    expect(subnetNode!.hidden).toBe(true);
+    expect(ec2Node!.hidden).toBe(true);
+  });
+
+  it("hides resources when subnet is collapsed", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          id: "sub-1",
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "ec2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const collapsed = new Set(["subnet-sub-1"]);
+    const result = calculateTopologyLayout(makeResponse([vpc]), collapsed);
+    const subnetNode = result.nodes.find((n) => n.id === "subnet-sub-1");
+    const ec2Node = result.nodes.find((n) => n.id === "ec2-i-1");
+    expect(subnetNode!.data).toHaveProperty("collapsed", true);
+    expect(ec2Node!.hidden).toBe(true);
+  });
+
+  it("includes correct childSummary counts on VPC node", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "ec2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+          rds_instances: [
+            {
+              id: "rds-1",
+              name: "db",
+              engine: "mysql",
+              instance_class: "db.t3.micro",
+              status: "available",
+              display_status: "active",
+              endpoint: null,
+              port: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+      internet_gateway: {
+        id: "igw-1",
+        name: "IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: false,
+        tf_resource_address: null,
+      },
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const vpcNode = result.nodes.find((n) => n.id === "vpc-vpc-1");
+    const summary = (
+      vpcNode!.data as unknown as { childSummary: Record<string, number> }
+    ).childSummary;
+    expect(summary.subnetCount).toBe(1);
+    expect(summary.ec2Count).toBe(1);
+    expect(summary.rdsCount).toBe(1);
+    expect(summary.igwCount).toBe(1);
+  });
+
+  it("includes correct childSummary counts on subnet node", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "ec2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+            {
+              id: "i-2",
+              name: "ec2-2",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const subnetNode = result.nodes.find((n) => n.id === "subnet-subnet-1");
+    const summary = (
+      subnetNode!.data as unknown as { childSummary: Record<string, number> }
+    ).childSummary;
+    expect(summary.ec2Count).toBe(2);
+  });
+
+  it("falls back to ID when resource name is null", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-fallback",
+              name: null,
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: false,
+              tf_resource_address: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const ec2Node = result.nodes.find((n) => n.id === "ec2-i-fallback");
+    expect(ec2Node!.data.label).toBe("i-fallback");
+  });
+
+  it("maps tf_resource_address when present", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          ec2_instances: [
+            {
+              id: "i-1",
+              name: "web",
+              instance_type: "t3.micro",
+              state: "running",
+              display_status: "active",
+              private_ip: null,
+              public_ip: null,
+              private_dns: null,
+              public_dns: null,
+              tf_managed: true,
+              tf_resource_address: "aws_instance.web",
+            },
+          ],
+        }),
+      ],
+    });
+    const result = calculateTopologyLayout(makeResponse([vpc]));
+    const ec2Node = result.nodes.find((n) => n.id === "ec2-i-1");
+    expect(ec2Node!.data.tfResourceAddress).toBe("aws_instance.web");
+  });
+});
+
+// =============================================================================
+// createEdges
+// =============================================================================
+
+describe("createEdges", () => {
+  it("returns empty array for empty data", () => {
+    expect(createEdges(makeResponse([]))).toEqual([]);
+  });
+
+  it("creates edge from IGW to public subnet", () => {
+    const vpc = makeVPC({
+      internet_gateway: {
+        id: "igw-1",
+        name: "IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: false,
+        tf_resource_address: null,
+      },
+      subnets: [makeSubnet({ id: "sub-1", subnet_type: "public" })],
+    });
+    const edges = createEdges(makeResponse([vpc]));
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe("igw-igw-1");
+    expect(edges[0].target).toBe("subnet-sub-1");
+  });
+
+  it("creates edges from IGW to all public subnets", () => {
+    const vpc = makeVPC({
+      internet_gateway: {
+        id: "igw-1",
+        name: "IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: false,
+        tf_resource_address: null,
+      },
+      subnets: [
+        makeSubnet({ id: "sub-1", subnet_type: "public" }),
+        makeSubnet({ id: "sub-2", subnet_type: "public" }),
+      ],
+    });
+    const edges = createEdges(makeResponse([vpc]));
+    expect(edges).toHaveLength(2);
+  });
+
+  it("does not create IGW edges to private subnets", () => {
+    const vpc = makeVPC({
+      internet_gateway: {
+        id: "igw-1",
+        name: "IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: false,
+        tf_resource_address: null,
+      },
+      subnets: [makeSubnet({ id: "sub-1", subnet_type: "private" })],
+    });
+    const edges = createEdges(makeResponse([vpc]));
+    expect(edges).toHaveLength(0);
+  });
+
+  it("creates NAT edges from public subnet NAT to private subnets", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          id: "pub-1",
+          subnet_type: "public",
+          nat_gateway: {
+            id: "nat-1",
+            name: "NAT",
+            state: "available",
+            display_status: "active",
+            primary_public_ip: null,
+            tf_managed: false,
+            tf_resource_address: null,
+          },
+        }),
+        makeSubnet({ id: "priv-1", subnet_type: "private" }),
+      ],
+    });
+    const edges = createEdges(makeResponse([vpc]));
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe("nat-nat-1");
+    expect(edges[0].target).toBe("subnet-priv-1");
+  });
+
+  it("creates NAT edges to multiple private subnets", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          id: "pub-1",
+          subnet_type: "public",
+          nat_gateway: {
+            id: "nat-1",
+            name: "NAT",
+            state: "available",
+            display_status: "active",
+            primary_public_ip: null,
+            tf_managed: false,
+            tf_resource_address: null,
+          },
+        }),
+        makeSubnet({ id: "priv-1", subnet_type: "private" }),
+        makeSubnet({ id: "priv-2", subnet_type: "private" }),
+      ],
+    });
+    const edges = createEdges(makeResponse([vpc]));
+    expect(edges).toHaveLength(2);
+  });
+
+  it("skips all edges for collapsed VPC", () => {
+    const vpc = makeVPC({
+      internet_gateway: {
+        id: "igw-1",
+        name: "IGW",
+        state: "attached",
+        display_status: "active",
+        tf_managed: false,
+        tf_resource_address: null,
+      },
+      subnets: [makeSubnet({ id: "sub-1", subnet_type: "public" })],
+    });
+    const collapsed = new Set(["vpc-vpc-1"]);
+    const edges = createEdges(makeResponse([vpc]), collapsed);
+    expect(edges).toHaveLength(0);
+  });
+
+  it("skips NAT edges when subnet containing NAT is collapsed", () => {
+    const vpc = makeVPC({
+      subnets: [
+        makeSubnet({
+          id: "pub-1",
+          subnet_type: "public",
+          nat_gateway: {
+            id: "nat-1",
+            name: "NAT",
+            state: "available",
+            display_status: "active",
+            primary_public_ip: null,
+            tf_managed: false,
+            tf_resource_address: null,
+          },
+        }),
+        makeSubnet({ id: "priv-1", subnet_type: "private" }),
+      ],
+    });
+    const collapsed = new Set(["subnet-pub-1"]);
+    const edges = createEdges(makeResponse([vpc]), collapsed);
+    expect(edges).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/topology/utils/topologyFilter.test.ts
+++ b/frontend/src/components/topology/utils/topologyFilter.test.ts
@@ -1,0 +1,616 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasActiveFilters,
+  filterTopologyData,
+  EMPTY_FILTERS,
+} from "./topologyFilter";
+import type {
+  TopologyResponse,
+  TopologyVPC,
+  TopologySubnet,
+  TopologyFilters,
+} from "@/types/topology";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeSubnet(overrides: Partial<TopologySubnet> = {}): TopologySubnet {
+  return {
+    id: "subnet-1",
+    name: "Test Subnet",
+    cidr_block: "10.0.1.0/24",
+    availability_zone: "us-east-1a",
+    subnet_type: "public",
+    display_status: "active",
+    tf_managed: false,
+    tf_resource_address: null,
+    nat_gateway: null,
+    ec2_instances: [],
+    rds_instances: [],
+    ecs_containers: [],
+    ...overrides,
+  };
+}
+
+function makeVPC(overrides: Partial<TopologyVPC> = {}): TopologyVPC {
+  return {
+    id: "vpc-1",
+    name: "Test VPC",
+    cidr_block: "10.0.0.0/16",
+    state: "available",
+    display_status: "active",
+    tf_managed: false,
+    tf_resource_address: null,
+    internet_gateway: null,
+    subnets: [],
+    elastic_ips: [],
+    ...overrides,
+  };
+}
+
+function makeResponse(vpcs: TopologyVPC[]): TopologyResponse {
+  return {
+    vpcs,
+    meta: {
+      total_vpcs: vpcs.length,
+      total_subnets: 0,
+      total_ec2: 0,
+      total_rds: 0,
+      total_ecs_containers: 0,
+      total_nat_gateways: 0,
+      total_internet_gateways: 0,
+      total_elastic_ips: 0,
+      last_refreshed: null,
+    },
+  };
+}
+
+function filters(overrides: Partial<TopologyFilters> = {}): TopologyFilters {
+  return { ...EMPTY_FILTERS, ...overrides };
+}
+
+// =============================================================================
+// EMPTY_FILTERS / hasActiveFilters
+// =============================================================================
+
+describe("EMPTY_FILTERS", () => {
+  it("has all empty values", () => {
+    expect(EMPTY_FILTERS.search).toBe("");
+    expect(EMPTY_FILTERS.vpcId).toBe("");
+    expect(EMPTY_FILTERS.subnetType).toBe("");
+    expect(EMPTY_FILTERS.status).toBe("");
+    expect(EMPTY_FILTERS.tfManaged).toBe("");
+    expect(EMPTY_FILTERS.resourceTypes).toEqual([]);
+  });
+});
+
+describe("hasActiveFilters", () => {
+  it("returns false for EMPTY_FILTERS", () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false);
+  });
+
+  it("returns true when search is set", () => {
+    expect(hasActiveFilters(filters({ search: "web" }))).toBe(true);
+  });
+
+  it("returns true when vpcId is set", () => {
+    expect(hasActiveFilters(filters({ vpcId: "vpc-1" }))).toBe(true);
+  });
+
+  it("returns true when resourceTypes is set", () => {
+    expect(hasActiveFilters(filters({ resourceTypes: ["ec2"] }))).toBe(true);
+  });
+
+  it("returns true when tfManaged is set", () => {
+    expect(hasActiveFilters(filters({ tfManaged: "true" }))).toBe(true);
+  });
+
+  it("returns true when status is set", () => {
+    expect(hasActiveFilters(filters({ status: "active" }))).toBe(true);
+  });
+
+  it("returns true when subnetType is set", () => {
+    expect(hasActiveFilters(filters({ subnetType: "public" }))).toBe(true);
+  });
+});
+
+// =============================================================================
+// filterTopologyData
+// =============================================================================
+
+describe("filterTopologyData", () => {
+  it("returns original data when no filters active", () => {
+    const data = makeResponse([makeVPC()]);
+    const result = filterTopologyData(data, EMPTY_FILTERS);
+    expect(result).toBe(data);
+  });
+
+  it("filters by vpcId", () => {
+    const data = makeResponse([
+      makeVPC({ id: "vpc-1", subnets: [makeSubnet()] }),
+      makeVPC({ id: "vpc-2", subnets: [makeSubnet({ id: "sub-2" })] }),
+    ]);
+    const result = filterTopologyData(data, filters({ vpcId: "vpc-1" }));
+    expect(result.vpcs).toHaveLength(1);
+    expect(result.vpcs[0].id).toBe("vpc-1");
+  });
+
+  it("filters by subnetType public - removes private subnets", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({ id: "pub-1", subnet_type: "public" }),
+          makeSubnet({ id: "priv-1", subnet_type: "private" }),
+        ],
+        internet_gateway: {
+          id: "igw-1",
+          name: "IGW",
+          state: "attached",
+          display_status: "active",
+          tf_managed: false,
+          tf_resource_address: null,
+        },
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ subnetType: "public" }));
+    expect(result.vpcs[0].subnets).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].id).toBe("pub-1");
+  });
+
+  it("filters by resourceTypes ec2 - keeps only EC2", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+            rds_instances: [
+              {
+                id: "rds-1",
+                name: "db",
+                engine: "mysql",
+                instance_class: "db.t3.micro",
+                status: "available",
+                display_status: "active",
+                endpoint: null,
+                port: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(
+      data,
+      filters({ resourceTypes: ["ec2"] }),
+    );
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].rds_instances).toHaveLength(0);
+  });
+
+  it("filters by resourceTypes rds - keeps only RDS", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+            rds_instances: [
+              {
+                id: "rds-1",
+                name: "db",
+                engine: "mysql",
+                instance_class: "db.t3.micro",
+                status: "available",
+                display_status: "active",
+                endpoint: null,
+                port: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(
+      data,
+      filters({ resourceTypes: ["rds"] }),
+    );
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(0);
+    expect(result.vpcs[0].subnets[0].rds_instances).toHaveLength(1);
+  });
+
+  it("filters by status active", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "active-ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+              {
+                id: "i-2",
+                name: "stopped-ec2",
+                instance_type: "t3.micro",
+                state: "stopped",
+                display_status: "inactive",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ status: "active" }));
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].ec2_instances[0].id).toBe("i-1");
+  });
+
+  it("filters by tfManaged true - keeps tf_managed only", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "managed",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: true,
+                tf_resource_address: "aws_instance.managed",
+              },
+              {
+                id: "i-2",
+                name: "unmanaged",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ tfManaged: "true" }));
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].ec2_instances[0].tf_managed).toBe(true);
+  });
+
+  it("filters by tfManaged false - keeps non-tf_managed only", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "managed",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: true,
+                tf_resource_address: "aws_instance.managed",
+              },
+              {
+                id: "i-2",
+                name: "unmanaged",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ tfManaged: "false" }));
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].ec2_instances[0].tf_managed).toBe(false);
+  });
+
+  it("filters by search matching EC2 name", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "web-server",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+              {
+                id: "i-2",
+                name: "api-server",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ search: "web" }));
+    expect(result.vpcs[0].subnets[0].ec2_instances).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].ec2_instances[0].name).toBe("web-server");
+  });
+
+  it("search matches subnet name and keeps entire subnet", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({ id: "sub-1", name: "my-cool-subnet" }),
+          makeSubnet({ id: "sub-2", name: "other-subnet" }),
+        ],
+        internet_gateway: {
+          id: "igw-1",
+          name: "IGW",
+          state: "attached",
+          display_status: "active",
+          tf_managed: false,
+          tf_resource_address: null,
+        },
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ search: "cool" }));
+    expect(result.vpcs[0].subnets.some((s) => s.id === "sub-1")).toBe(true);
+  });
+
+  it("search matches VPC name", () => {
+    const data = makeResponse([
+      makeVPC({
+        id: "vpc-1",
+        name: "production-vpc",
+        subnets: [makeSubnet()],
+      }),
+      makeVPC({
+        id: "vpc-2",
+        name: "staging-vpc",
+        subnets: [makeSubnet({ id: "sub-2" })],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ search: "production" }));
+    expect(result.vpcs.some((v) => v.id === "vpc-1")).toBe(true);
+  });
+
+  it("combines multiple filters: vpcId + subnetType + status", () => {
+    const data = makeResponse([
+      makeVPC({
+        id: "vpc-1",
+        subnets: [
+          makeSubnet({
+            id: "pub-1",
+            subnet_type: "public",
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "active-ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+          makeSubnet({ id: "priv-1", subnet_type: "private" }),
+        ],
+        internet_gateway: {
+          id: "igw-1",
+          name: "IGW",
+          state: "attached",
+          display_status: "active",
+          tf_managed: false,
+          tf_resource_address: null,
+        },
+      }),
+      makeVPC({ id: "vpc-2", subnets: [makeSubnet({ id: "sub-other" })] }),
+    ]);
+    const result = filterTopologyData(
+      data,
+      filters({
+        vpcId: "vpc-1",
+        subnetType: "public",
+        status: "active",
+      }),
+    );
+    expect(result.vpcs).toHaveLength(1);
+    expect(result.vpcs[0].id).toBe("vpc-1");
+    expect(result.vpcs[0].subnets).toHaveLength(1);
+    expect(result.vpcs[0].subnets[0].subnet_type).toBe("public");
+  });
+
+  it("recalculates meta counts after filtering", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: true,
+                tf_resource_address: null,
+              },
+              {
+                id: "i-2",
+                name: "ec2-2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: false,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const result = filterTopologyData(data, filters({ tfManaged: "true" }));
+    expect(result.meta.total_ec2).toBe(1);
+  });
+
+  it("resourceTypes igw keeps IGW", () => {
+    const data = makeResponse([
+      makeVPC({
+        internet_gateway: {
+          id: "igw-1",
+          name: "IGW",
+          state: "attached",
+          display_status: "active",
+          tf_managed: false,
+          tf_resource_address: null,
+        },
+        subnets: [makeSubnet()],
+      }),
+    ]);
+    const result = filterTopologyData(
+      data,
+      filters({ resourceTypes: ["igw"] }),
+    );
+    expect(result.vpcs[0].internet_gateway).not.toBeNull();
+  });
+
+  it("removes empty subnets after resource filtering", () => {
+    const data = makeResponse([
+      makeVPC({
+        subnets: [
+          makeSubnet({
+            id: "sub-1",
+            ec2_instances: [
+              {
+                id: "i-1",
+                name: "ec2",
+                instance_type: "t3.micro",
+                state: "running",
+                display_status: "active",
+                private_ip: null,
+                public_ip: null,
+                private_dns: null,
+                public_dns: null,
+                tf_managed: true,
+                tf_resource_address: null,
+              },
+            ],
+          }),
+          makeSubnet({
+            id: "sub-2",
+            ec2_instances: [],
+            tf_managed: false,
+          }),
+        ],
+        internet_gateway: {
+          id: "igw-1",
+          name: "IGW",
+          state: "attached",
+          display_status: "active",
+          tf_managed: false,
+          tf_resource_address: null,
+        },
+      }),
+    ]);
+    // Filter by search for "ec2" - sub-2 has no matching children and doesn't match search
+    const result = filterTopologyData(data, filters({ search: "ec2" }));
+    // sub-2 should be removed since it has no matching children and doesn't match search
+    const sub2 = result.vpcs[0]?.subnets.find((s) => s.id === "sub-2");
+    expect(sub2).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useResources.cyberark.test.ts
+++ b/frontend/src/hooks/useResources.cyberark.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+import {
+  queryKeys,
+  useECSClusters,
+  useECSSummary,
+  useS3Buckets,
+  useS3Bucket,
+  useRefreshData,
+  useCyberArkSafes,
+  useCyberArkSafe,
+  useCyberArkRoles,
+  useCyberArkRole,
+  useCyberArkSIAPolicies,
+  useCyberArkSIAPolicy,
+  useCyberArkDrift,
+  useCyberArkUsers,
+  useAccessMapping,
+  useAccessMappingUsers,
+  useAccessMappingTargets,
+} from "./useResources";
+
+// =============================================================================
+// Mock API
+// =============================================================================
+
+vi.mock("@/api", () => ({
+  getStatusSummary: vi.fn(() => Promise.resolve({})),
+  getAppInfo: vi.fn(() => Promise.resolve({})),
+  getEC2Instances: vi.fn(() => Promise.resolve({ data: [] })),
+  getEC2Instance: vi.fn(() => Promise.resolve({})),
+  getRDSInstances: vi.fn(() => Promise.resolve({ data: [] })),
+  getRDSInstance: vi.fn(() => Promise.resolve({})),
+  getECSContainers: vi.fn(() => Promise.resolve({ data: [] })),
+  getECSContainer: vi.fn(() => Promise.resolve({})),
+  getECSClusters: vi.fn(() =>
+    Promise.resolve({
+      data: [
+        {
+          cluster_name: "prod",
+          total_tasks: 3,
+          running_tasks: 2,
+          stopped_tasks: 1,
+          pending_tasks: 0,
+          containers: [],
+        },
+      ],
+    }),
+  ),
+  getECSSummary: vi.fn(() =>
+    Promise.resolve({
+      clusters: 2,
+      services: 3,
+      total_tasks: 5,
+      running_tasks: 4,
+      stopped_tasks: 1,
+      pending_tasks: 0,
+    }),
+  ),
+  getVPCs: vi.fn(() => Promise.resolve({ data: [] })),
+  getVPC: vi.fn(() => Promise.resolve({})),
+  getSubnets: vi.fn(() => Promise.resolve({ data: [] })),
+  getSubnet: vi.fn(() => Promise.resolve({})),
+  getInternetGateways: vi.fn(() => Promise.resolve({ data: [] })),
+  getInternetGateway: vi.fn(() => Promise.resolve({})),
+  getNATGateways: vi.fn(() => Promise.resolve({ data: [] })),
+  getNATGateway: vi.fn(() => Promise.resolve({})),
+  getElasticIPs: vi.fn(() => Promise.resolve({ data: [] })),
+  getElasticIP: vi.fn(() => Promise.resolve({})),
+  getS3Buckets: vi.fn(() =>
+    Promise.resolve({
+      data: [{ bucket_name: "my-bucket", region: "us-east-1" }],
+      meta: { total: 1 },
+    }),
+  ),
+  getS3Bucket: vi.fn((name: string) =>
+    Promise.resolve({ bucket_name: name, region: "us-east-1" }),
+  ),
+  refreshData: vi.fn(() => Promise.resolve({ success: true })),
+  getTerraformStates: vi.fn(() => Promise.resolve({ states: [] })),
+  getDrift: vi.fn(() => Promise.resolve({ drift_detected: false, items: [] })),
+  getTopology: vi.fn(() => Promise.resolve({ vpcs: [], meta: {} })),
+  getCyberArkSafes: vi.fn(() =>
+    Promise.resolve({
+      data: [{ safe_name: "AdminSafe", description: "Admin safe" }],
+      meta: { total: 1 },
+    }),
+  ),
+  getCyberArkSafe: vi.fn((name: string) =>
+    Promise.resolve({ safe_name: name, description: "test" }),
+  ),
+  getCyberArkRoles: vi.fn(() =>
+    Promise.resolve({
+      data: [{ role_id: "role-1", role_name: "Admin" }],
+      meta: { total: 1 },
+    }),
+  ),
+  getCyberArkRole: vi.fn((id: string) =>
+    Promise.resolve({ role_id: id, role_name: "Admin" }),
+  ),
+  getCyberArkSIAPolicies: vi.fn(() =>
+    Promise.resolve({
+      data: [{ policy_id: "pol-1", policy_name: "Default" }],
+      meta: { total: 1 },
+    }),
+  ),
+  getCyberArkSIAPolicy: vi.fn((id: string) =>
+    Promise.resolve({ policy_id: id, policy_name: "Default" }),
+  ),
+  getCyberArkDrift: vi.fn(() =>
+    Promise.resolve({ drift_detected: false, items: [] }),
+  ),
+  getCyberArkUsers: vi.fn(() =>
+    Promise.resolve({
+      data: [{ user_id: "u1", user_name: "john" }],
+      meta: { total: 1 },
+    }),
+  ),
+  getAccessMapping: vi.fn(() =>
+    Promise.resolve({
+      users: [{ user_id: "u1" }],
+      targets: [],
+      total_users: 1,
+      total_targets: 0,
+      total_standing_paths: 0,
+      total_jit_paths: 0,
+    }),
+  ),
+  getAccessMappingUsers: vi.fn(() =>
+    Promise.resolve({ users: [{ user_id: "u1", user_name: "john" }] }),
+  ),
+  getAccessMappingTargets: vi.fn(() =>
+    Promise.resolve({ targets: [{ target_id: "t1" }] }),
+  ),
+}));
+
+// =============================================================================
+// Helper
+// =============================================================================
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+// =============================================================================
+// ECS Clusters
+// =============================================================================
+
+describe("useECSClusters", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches ECS clusters", async () => {
+    const { result } = renderHook(() => useECSClusters(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+    expect(result.current.data?.data[0].cluster_name).toBe("prod");
+  });
+
+  it("passes filters to query", async () => {
+    const { result } = renderHook(() => useECSClusters({ search: "prod" }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useECSSummary", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches ECS summary", async () => {
+    const { result } = renderHook(() => useECSSummary(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.clusters).toBe(2);
+  });
+});
+
+// =============================================================================
+// S3 Buckets
+// =============================================================================
+
+describe("useS3Buckets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches S3 buckets", async () => {
+    const { result } = renderHook(() => useS3Buckets(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+  });
+});
+
+describe("useS3Bucket", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches single S3 bucket", async () => {
+    const { result } = renderHook(() => useS3Bucket("my-bucket"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.bucket_name).toBe("my-bucket");
+  });
+
+  it("is disabled when name is empty", () => {
+    const { result } = renderHook(() => useS3Bucket(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// =============================================================================
+// Refresh Data
+// =============================================================================
+
+describe("useRefreshData", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("provides a mutation function", async () => {
+    const { result } = renderHook(() => useRefreshData(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.mutateAsync).toBeDefined();
+  });
+});
+
+// =============================================================================
+// CyberArk Safes
+// =============================================================================
+
+describe("useCyberArkSafes", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches safes", async () => {
+    const { result } = renderHook(() => useCyberArkSafes(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+    expect(result.current.data?.data[0].safe_name).toBe("AdminSafe");
+  });
+
+  it("passes filters", async () => {
+    const { result } = renderHook(() => useCyberArkSafes({ search: "admin" }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useCyberArkSafe", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches single safe", async () => {
+    const { result } = renderHook(() => useCyberArkSafe("AdminSafe"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.safe_name).toBe("AdminSafe");
+  });
+
+  it("is disabled when name is empty", () => {
+    const { result } = renderHook(() => useCyberArkSafe(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// =============================================================================
+// CyberArk Roles
+// =============================================================================
+
+describe("useCyberArkRoles", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches roles", async () => {
+    const { result } = renderHook(() => useCyberArkRoles(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+  });
+});
+
+describe("useCyberArkRole", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches single role", async () => {
+    const { result } = renderHook(() => useCyberArkRole("role-1"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.role_id).toBe("role-1");
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHook(() => useCyberArkRole(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// =============================================================================
+// CyberArk SIA Policies
+// =============================================================================
+
+describe("useCyberArkSIAPolicies", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches SIA policies", async () => {
+    const { result } = renderHook(() => useCyberArkSIAPolicies(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+  });
+});
+
+describe("useCyberArkSIAPolicy", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches single policy", async () => {
+    const { result } = renderHook(() => useCyberArkSIAPolicy("pol-1"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.policy_id).toBe("pol-1");
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHook(() => useCyberArkSIAPolicy(""), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+// =============================================================================
+// CyberArk Drift
+// =============================================================================
+
+describe("useCyberArkDrift", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches drift data", async () => {
+    const { result } = renderHook(() => useCyberArkDrift(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.drift_detected).toBe(false);
+  });
+});
+
+// =============================================================================
+// CyberArk Users
+// =============================================================================
+
+describe("useCyberArkUsers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches users", async () => {
+    const { result } = renderHook(() => useCyberArkUsers(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toHaveLength(1);
+  });
+
+  it("passes filters", async () => {
+    const { result } = renderHook(() => useCyberArkUsers({ search: "john" }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+// =============================================================================
+// Access Mapping
+// =============================================================================
+
+describe("useAccessMapping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches access mapping", async () => {
+    const { result } = renderHook(() => useAccessMapping(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.total_users).toBe(1);
+  });
+
+  it("passes user param", async () => {
+    const { result } = renderHook(() => useAccessMapping({ user: "john" }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useAccessMappingUsers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches access mapping users", async () => {
+    const { result } = renderHook(() => useAccessMappingUsers(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.users).toHaveLength(1);
+  });
+});
+
+describe("useAccessMappingTargets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches access mapping targets", async () => {
+    const { result } = renderHook(() => useAccessMappingTargets(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.targets).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Query Key Shape Tests
+// =============================================================================
+
+describe("queryKeys - CyberArk/Access Mapping/S3", () => {
+  it("generates correct cyberark-safes key", () => {
+    expect(queryKeys.cyberArkSafes()).toEqual(["cyberark-safes", undefined]);
+  });
+
+  it("generates correct cyberark-safes key with filters", () => {
+    const f = { search: "test" };
+    expect(queryKeys.cyberArkSafes(f)).toEqual(["cyberark-safes", f]);
+  });
+
+  it("generates correct cyberark-role key", () => {
+    expect(queryKeys.cyberArkRole("r1")).toEqual(["cyberark-role", "r1"]);
+  });
+
+  it("generates correct access-mapping key", () => {
+    expect(queryKeys.accessMapping()).toEqual(["access-mapping", undefined]);
+  });
+
+  it("generates correct access-mapping-users key", () => {
+    expect(queryKeys.accessMappingUsers).toEqual(["access-mapping-users"]);
+  });
+
+  it("generates correct access-mapping-targets key", () => {
+    expect(queryKeys.accessMappingTargets).toEqual(["access-mapping-targets"]);
+  });
+
+  it("generates correct s3-buckets key", () => {
+    expect(queryKeys.s3Buckets()).toEqual(["s3-buckets", undefined]);
+  });
+
+  it("generates correct s3-bucket key", () => {
+    expect(queryKeys.s3Bucket("my-bucket")).toEqual(["s3-bucket", "my-bucket"]);
+  });
+
+  it("generates correct ecs-clusters key", () => {
+    expect(queryKeys.ecsClusters()).toEqual(["ecs-clusters", undefined]);
+  });
+
+  it("generates correct ecs-summary key", () => {
+    expect(queryKeys.ecsSummary).toEqual(["ecs-summary"]);
+  });
+
+  it("generates correct cyberark-drift key", () => {
+    expect(queryKeys.cyberArkDrift).toEqual(["cyberark-drift"]);
+  });
+
+  it("generates correct cyberark-users key with filters", () => {
+    const f = { active: true };
+    expect(queryKeys.cyberArkUsers(f)).toEqual(["cyberark-users", f]);
+  });
+});

--- a/frontend/src/pages/AccessMappingPage.test.tsx
+++ b/frontend/src/pages/AccessMappingPage.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import { AccessMappingPage } from "./AccessMappingPage";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockAccessData = {
+  users: [
+    { user_id: "u1", user_name: "john", display_name: "John", paths: [] },
+  ],
+  targets: [],
+  total_users: 1,
+  total_targets: 0,
+  total_standing_paths: 2,
+  total_jit_paths: 1,
+};
+
+let mockData: typeof mockAccessData | null = mockAccessData;
+let mockIsLoading = false;
+let mockIsError = false;
+let mockError: Error | null = null;
+const mockRefetch = vi.fn();
+const mockMutateAsync = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useAccessMapping: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    error: mockError,
+    refetch: mockRefetch,
+  }),
+  useAccessMappingUsers: () => ({
+    data: { users: [] },
+  }),
+  useRefreshData: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+let mockAuthUser: { is_admin: boolean } | null = { is_admin: true };
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: mockAuthUser,
+  }),
+}));
+
+// Mock child components as stubs
+vi.mock("@/components/access-mapping/AccessMappingCanvas", () => ({
+  AccessMappingCanvas: () => <div data-testid="canvas">Canvas</div>,
+}));
+
+vi.mock("@/components/access-mapping/AccessMappingDetailPanel", () => ({
+  AccessMappingDetailPanel: () => <div data-testid="detail-panel">Detail</div>,
+}));
+
+vi.mock("@/components/access-mapping/AccessMappingFilterBar", () => ({
+  AccessMappingFilterBar: () => <div data-testid="filter-bar">FilterBar</div>,
+}));
+
+vi.mock("@/components/access-mapping/AccessMappingLegend", () => ({
+  AccessMappingLegend: () => <div data-testid="legend">Legend</div>,
+}));
+
+describe("AccessMappingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = mockAccessData;
+    mockIsLoading = false;
+    mockIsError = false;
+    mockError = null;
+    mockAuthUser = { is_admin: true };
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    render(<AccessMappingPage />);
+    expect(
+      screen.getByText("Loading access mapping data..."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error state with message", () => {
+    mockIsError = true;
+    mockError = new Error("Network failure");
+    mockData = null;
+    render(<AccessMappingPage />);
+    expect(
+      screen.getByText("Failed to load access mapping"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Network failure")).toBeInTheDocument();
+  });
+
+  it("error has Retry button calling refetch", () => {
+    mockIsError = true;
+    mockError = new Error("fail");
+    mockData = null;
+    render(<AccessMappingPage />);
+    const retryButton = screen.getByText("Retry");
+    fireEvent.click(retryButton);
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("shows empty state when no users", () => {
+    mockData = { ...mockAccessData, users: [] };
+    render(<AccessMappingPage />);
+    expect(
+      screen.getByText("No access mapping data found"),
+    ).toBeInTheDocument();
+  });
+
+  it("empty state shows Refresh Data button", () => {
+    mockData = { ...mockAccessData, users: [] };
+    render(<AccessMappingPage />);
+    expect(screen.getByText("Refresh Data")).toBeInTheDocument();
+  });
+
+  it("refresh button calls mutateAsync", async () => {
+    mockData = { ...mockAccessData, users: [] };
+    mockMutateAsync.mockResolvedValueOnce(undefined);
+    mockRefetch.mockResolvedValueOnce(undefined);
+    render(<AccessMappingPage />);
+    const refreshBtn = screen.getByText("Refresh Data");
+    fireEvent.click(refreshBtn);
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("renders canvas, filter bar, and legend with data", () => {
+    render(<AccessMappingPage />);
+    expect(screen.getByTestId("canvas")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("legend")).toBeInTheDocument();
+  });
+
+  it("handles null data gracefully", () => {
+    mockData = null;
+    mockIsLoading = false;
+    mockIsError = false;
+    render(<AccessMappingPage />);
+    // Should show empty state when data is null
+    expect(
+      screen.getByText("No access mapping data found"),
+    ).toBeInTheDocument();
+  });
+
+  it("handles undefined data gracefully", () => {
+    mockData = undefined as unknown as typeof mockAccessData;
+    mockIsLoading = false;
+    mockIsError = false;
+    render(<AccessMappingPage />);
+    expect(
+      screen.getByText("No access mapping data found"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CyberArkDashboard.test.tsx
+++ b/frontend/src/pages/CyberArkDashboard.test.tsx
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { CyberArkDashboardPage } from "./CyberArkDashboard";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockSafes = [
+  {
+    safe_name: "AdminSafe",
+    description: "Admin safe",
+    number_of_members: 5,
+    number_of_accounts: 10,
+    tf_managed: false,
+  },
+  {
+    safe_name: "AppSafe",
+    description: null,
+    number_of_members: 3,
+    number_of_accounts: 8,
+    tf_managed: true,
+  },
+];
+
+const mockRoles = [
+  {
+    role_id: "r1",
+    role_name: "Admin",
+    description: "Admin role",
+    tf_managed: true,
+  },
+  { role_id: "r2", role_name: "Viewer", description: null, tf_managed: false },
+];
+
+const mockPolicies = [
+  {
+    policy_id: "p1",
+    policy_name: "VMAccess",
+    policy_type: "vm",
+    status: "active",
+    tf_managed: false,
+  },
+  {
+    policy_id: "p2",
+    policy_name: "DBAccess",
+    policy_type: "database",
+    status: "inactive",
+    tf_managed: false,
+  },
+];
+
+const mockUsers = [
+  { user_id: "u1", user_name: "john", active: true },
+  { user_id: "u2", user_name: "jane", active: false },
+];
+
+let mockSafesData: {
+  data: typeof mockSafes;
+  meta: { total: number; last_refreshed: string | null };
+} | null = { data: mockSafes, meta: { total: 2, last_refreshed: null } };
+let mockRolesData: {
+  data: typeof mockRoles;
+  meta: { total: number; last_refreshed: string | null };
+} | null = { data: mockRoles, meta: { total: 2, last_refreshed: null } };
+let mockPoliciesData: {
+  data: typeof mockPolicies;
+  meta: { total: number; last_refreshed: string | null };
+} | null = { data: mockPolicies, meta: { total: 2, last_refreshed: null } };
+let mockUsersData: {
+  data: typeof mockUsers;
+  meta: { total: number; last_refreshed: string | null };
+} | null = { data: mockUsers, meta: { total: 2, last_refreshed: null } };
+let mockDriftData: {
+  drift_detected: boolean;
+  items: Array<{
+    resource_type: string;
+    resource_id: string;
+    drift_type: string;
+  }>;
+} | null = { drift_detected: false, items: [] };
+
+let mockSafesLoading = false;
+let mockRolesLoading = false;
+let mockPoliciesLoading = false;
+let mockUsersLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkSafes: () => ({
+    data: mockSafesData,
+    isLoading: mockSafesLoading,
+  }),
+  useCyberArkRoles: () => ({
+    data: mockRolesData,
+    isLoading: mockRolesLoading,
+  }),
+  useCyberArkSIAPolicies: () => ({
+    data: mockPoliciesData,
+    isLoading: mockPoliciesLoading,
+  }),
+  useCyberArkDrift: () => ({ data: mockDriftData }),
+  useCyberArkUsers: () => ({
+    data: mockUsersData,
+    isLoading: mockUsersLoading,
+  }),
+}));
+
+describe("CyberArkDashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSafesData = {
+      data: mockSafes,
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockRolesData = {
+      data: mockRoles,
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockPoliciesData = {
+      data: mockPolicies,
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockUsersData = {
+      data: mockUsers,
+      meta: { total: 2, last_refreshed: null },
+    };
+    mockDriftData = { drift_detected: false, items: [] };
+    mockSafesLoading = false;
+    mockRolesLoading = false;
+    mockPoliciesLoading = false;
+    mockUsersLoading = false;
+  });
+
+  it("renders CyberArk Dashboard heading", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("CyberArk Dashboard")).toBeInTheDocument();
+  });
+
+  it("renders subtitle", () => {
+    render(<CyberArkDashboardPage />);
+    expect(
+      screen.getByText("Overview of Identity Security resources"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading state when all hooks loading", () => {
+    mockSafesLoading = true;
+    mockRolesLoading = true;
+    mockPoliciesLoading = true;
+    mockUsersLoading = true;
+    const { container } = render(<CyberArkDashboardPage />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("renders summary stat cards with counts", () => {
+    render(<CyberArkDashboardPage />);
+    // SummaryStatCard renders the value
+    const twos = screen.getAllByText("2");
+    expect(twos.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("shows active subtitle for users and policies", () => {
+    render(<CyberArkDashboardPage />);
+    // "1 active" appears for both users (1 active user) and policies (1 active policy)
+    const activeTexts = screen.getAllByText("1 active");
+    expect(activeTexts).toHaveLength(2);
+  });
+
+  it("shows total accounts subtitle", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("18 accounts")).toBeInTheDocument();
+  });
+
+  it("shows no drift detected", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("No drift detected")).toBeInTheDocument();
+  });
+
+  it("shows drift items when drift detected", () => {
+    mockDriftData = {
+      drift_detected: true,
+      items: [
+        {
+          resource_type: "safe",
+          resource_id: "OrphanSafe",
+          drift_type: "orphaned",
+        },
+      ],
+    };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("1 drift item(s) detected")).toBeInTheDocument();
+    expect(screen.getByText("OrphanSafe")).toBeInTheDocument();
+    expect(screen.getByText("safe")).toBeInTheDocument();
+    expect(screen.getByText("orphaned")).toBeInTheDocument();
+  });
+
+  it("shows +N more items when more than 5 drift items", () => {
+    mockDriftData = {
+      drift_detected: true,
+      items: Array.from({ length: 7 }, (_, i) => ({
+        resource_type: "safe",
+        resource_id: `item-${i}`,
+        drift_type: "orphaned",
+      })),
+    };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("+2 more items")).toBeInTheDocument();
+  });
+
+  it("renders Recent Safes section", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("Recent Safes")).toBeInTheDocument();
+    expect(screen.getByText("AdminSafe")).toBeInTheDocument();
+    expect(screen.getByText("10 accounts")).toBeInTheDocument();
+    expect(screen.getByText("5 members")).toBeInTheDocument();
+  });
+
+  it("renders Recent Roles section", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("Recent Roles")).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  it("shows TF badge for terraform-managed roles", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("TF")).toBeInTheDocument();
+  });
+
+  it("renders Recent SIA Policies section", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("Recent SIA Policies")).toBeInTheDocument();
+    expect(screen.getByText("VMAccess")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no safes", () => {
+    mockSafesData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("No safes found")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no roles", () => {
+    mockRolesData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("No roles found")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no policies", () => {
+    mockPoliciesData = { data: [], meta: { total: 0, last_refreshed: null } };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("No SIA policies found")).toBeInTheDocument();
+  });
+
+  it("renders View all links", () => {
+    render(<CyberArkDashboardPage />);
+    const viewAllLinks = screen.getAllByText("View all →");
+    expect(viewAllLinks).toHaveLength(3);
+  });
+
+  it("shows last refreshed when available", () => {
+    mockSafesData = {
+      data: mockSafes,
+      meta: { total: 2, last_refreshed: new Date().toISOString() },
+    };
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText(/Data last refreshed/)).toBeInTheDocument();
+  });
+
+  it("handles null data gracefully", () => {
+    mockSafesData = null;
+    mockRolesData = null;
+    mockPoliciesData = null;
+    mockUsersData = null;
+    mockDriftData = null;
+    render(<CyberArkDashboardPage />);
+    // Should render with 0 counts
+    const zeros = screen.getAllByText("0");
+    expect(zeros.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders view links for stat cards", () => {
+    render(<CyberArkDashboardPage />);
+    expect(screen.getByText("View users →")).toBeInTheDocument();
+    expect(screen.getByText("View roles →")).toBeInTheDocument();
+    expect(screen.getByText("View safes →")).toBeInTheDocument();
+    expect(screen.getByText("View policies →")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CyberArkPage.test.tsx
+++ b/frontend/src/pages/CyberArkPage.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { CyberArkPage } from "./CyberArkPage";
+
+// Mock child components as simple stubs
+vi.mock("@/components/cyberark/CyberArkTabNavigation", () => ({
+  CyberArkTabNavigation: ({
+    activeTab,
+    onTabChange,
+  }: {
+    activeTab: string;
+    onTabChange: (tab: string) => void;
+  }) => (
+    <div data-testid="tab-nav">
+      <button onClick={() => onTabChange("safes")}>Safes</button>
+      <button onClick={() => onTabChange("roles")}>Roles</button>
+      <button onClick={() => onTabChange("users")}>Users</button>
+      <button onClick={() => onTabChange("sia-policies")}>SIA Policies</button>
+      <span data-testid="active-tab">{activeTab}</span>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/cyberark/SafeList", () => ({
+  SafeList: () => <div data-testid="safe-list">SafeList</div>,
+}));
+
+vi.mock("@/components/cyberark/RoleList", () => ({
+  RoleList: () => <div data-testid="role-list">RoleList</div>,
+}));
+
+vi.mock("@/components/cyberark/UserList", () => ({
+  UserList: () => <div data-testid="user-list">UserList</div>,
+}));
+
+vi.mock("@/components/cyberark/SIAPolicyList", () => ({
+  SIAPolicyList: () => <div data-testid="sia-policy-list">SIAPolicyList</div>,
+}));
+
+describe("CyberArkPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders CyberArk Resources heading", () => {
+    render(<CyberArkPage />);
+    expect(screen.getByText("CyberArk Resources")).toBeInTheDocument();
+  });
+
+  it("renders subtitle", () => {
+    render(<CyberArkPage />);
+    expect(
+      screen.getByText(
+        "Identity users and roles, Privilege Cloud safes, and SIA policies",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("defaults to safes tab with SafeList visible", () => {
+    render(<CyberArkPage />);
+    expect(screen.getByTestId("safe-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("role-list")).not.toBeInTheDocument();
+  });
+
+  it("clicking Roles tab shows RoleList", () => {
+    render(<CyberArkPage />);
+    fireEvent.click(screen.getByText("Roles"));
+    expect(screen.getByTestId("role-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("safe-list")).not.toBeInTheDocument();
+  });
+
+  it("clicking Users tab shows UserList", () => {
+    render(<CyberArkPage />);
+    fireEvent.click(screen.getByText("Users"));
+    expect(screen.getByTestId("user-list")).toBeInTheDocument();
+  });
+
+  it("clicking SIA Policies tab shows SIAPolicyList", () => {
+    render(<CyberArkPage />);
+    fireEvent.click(screen.getByText("SIA Policies"));
+    expect(screen.getByTestId("sia-policy-list")).toBeInTheDocument();
+  });
+
+  it("renders tab navigation", () => {
+    render(<CyberArkPage />);
+    expect(screen.getByTestId("tab-nav")).toBeInTheDocument();
+  });
+
+  it("clicking back to Safes shows SafeList again", () => {
+    render(<CyberArkPage />);
+    fireEvent.click(screen.getByText("Roles"));
+    expect(screen.getByTestId("role-list")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Safes"));
+    expect(screen.getByTestId("safe-list")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CyberArkUsersPage.test.tsx
+++ b/frontend/src/pages/CyberArkUsersPage.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { CyberArkUsersPage } from "./CyberArkUsersPage";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockUsers = [
+  {
+    user_id: "user-1",
+    user_name: "john.doe",
+    display_name: "John Doe",
+    email: "john@example.com",
+    active: true,
+  },
+  {
+    user_id: "user-2",
+    user_name: "jane.smith",
+    display_name: null,
+    email: null,
+    active: false,
+  },
+];
+
+let mockData: { data: typeof mockUsers; meta: { total: number } } | null = {
+  data: mockUsers,
+  meta: { total: 2 },
+};
+let mockIsLoading = false;
+
+vi.mock("@/hooks", () => ({
+  useCyberArkUsers: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+  }),
+}));
+
+describe("CyberArkUsersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = { data: mockUsers, meta: { total: 2 } };
+    mockIsLoading = false;
+  });
+
+  it("renders CyberArk Users heading", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("CyberArk Users")).toBeInTheDocument();
+  });
+
+  it("shows total count", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText(/2 total/)).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<CyberArkUsersPage />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("renders table headers", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("Username")).toBeInTheDocument();
+    expect(screen.getByText("Display Name")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("renders user rows", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("john.doe")).toBeInTheDocument();
+    expect(screen.getByText("jane.smith")).toBeInTheDocument();
+  });
+
+  it("shows dash for null display_name", () => {
+    render(<CyberArkUsersPage />);
+    // jane.smith has null display_name -> shows "-"
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows dash for null email", () => {
+    render(<CyberArkUsersPage />);
+    // jane.smith has null email -> shows "-"
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows Active badge for active user", () => {
+    render(<CyberArkUsersPage />);
+    // "Active" appears in both the status filter option and the badge
+    const activeTexts = screen.getAllByText("Active");
+    expect(activeTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows Inactive badge for inactive user", () => {
+    render(<CyberArkUsersPage />);
+    // "Inactive" appears in both the status filter option and the badge
+    const inactiveTexts = screen.getAllByText("Inactive");
+    expect(inactiveTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows No users found when empty data without filters", () => {
+    mockData = { data: [], meta: { total: 0 } };
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("No users found")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByPlaceholderText("Search users...")).toBeInTheDocument();
+  });
+
+  it("renders status filter dropdown", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("All statuses")).toBeInTheDocument();
+  });
+
+  it("renders display name and email for user with data", () => {
+    render(<CyberArkUsersPage />);
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("john@example.com")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Dashboard.cyberark.test.tsx
+++ b/frontend/src/pages/Dashboard.cyberark.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { DashboardPage } from "./Dashboard";
+
+// =============================================================================
+// Mock hooks with CyberArk data
+// =============================================================================
+
+let mockCyberArkSafesTotal = 12;
+let mockCyberArkRolesTotal = 8;
+let mockCyberArkPoliciesTotal = 3;
+let mockCyberArkDriftData: {
+  drift_detected: boolean;
+  items: { id: string }[];
+} = { drift_detected: false, items: [] };
+
+vi.mock("@/hooks", () => ({
+  useStatusSummary: () => ({
+    data: {
+      ec2: { total: 1, active: 1, inactive: 0, transitioning: 0, error: 0 },
+      rds: { total: 0, active: 0, inactive: 0, transitioning: 0, error: 0 },
+      last_refreshed: "2024-01-15T12:00:00Z",
+    },
+    isLoading: false,
+  }),
+  useEC2Instances: () => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+  }),
+  useRDSInstances: () => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+  }),
+  useECSContainers: () => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+  }),
+  useDrift: () => ({
+    data: { drift_detected: false, items: [] },
+  }),
+  useVPCs: () => ({
+    data: { data: [], meta: { total: 0 }, total: 0 },
+    isLoading: false,
+  }),
+  useSubnets: () => ({ data: { data: [], meta: { total: 0 } } }),
+  useInternetGateways: () => ({ data: { data: [], meta: { total: 0 } } }),
+  useNATGateways: () => ({ data: { data: [], meta: { total: 0 } } }),
+  useElasticIPs: () => ({ data: { data: [], meta: { total: 0 } } }),
+  useCyberArkSafes: () => ({
+    data: { data: [], meta: { total: mockCyberArkSafesTotal } },
+  }),
+  useCyberArkRoles: () => ({
+    data: { data: [], meta: { total: mockCyberArkRolesTotal } },
+  }),
+  useCyberArkSIAPolicies: () => ({
+    data: { data: [], meta: { total: mockCyberArkPoliciesTotal } },
+  }),
+  useCyberArkDrift: () => ({
+    data: mockCyberArkDriftData,
+  }),
+}));
+
+describe("DashboardPage - CyberArk section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCyberArkSafesTotal = 12;
+    mockCyberArkRolesTotal = 8;
+    mockCyberArkPoliciesTotal = 3;
+    mockCyberArkDriftData = { drift_detected: false, items: [] };
+  });
+
+  it("renders CyberArk Identity Security heading", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("CyberArk Identity Security")).toBeInTheDocument();
+  });
+
+  it("renders View CyberArk Dashboard link", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("View CyberArk Dashboard →")).toBeInTheDocument();
+  });
+
+  it("shows Safes count", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("Safes")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("shows Roles count", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+  });
+
+  it("shows SIA Policies count", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("SIA Policies")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows None when no CyberArk drift detected", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  it("shows drift count when drift detected", () => {
+    mockCyberArkDriftData = {
+      drift_detected: true,
+      items: [{ id: "d1" }, { id: "d2" }],
+    };
+    render(<DashboardPage />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("renders View safes link", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("View safes →")).toBeInTheDocument();
+  });
+
+  it("renders View roles link", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("View roles →")).toBeInTheDocument();
+  });
+
+  it("renders View policies link", () => {
+    render(<DashboardPage />);
+    expect(screen.getByText("View policies →")).toBeInTheDocument();
+  });
+
+  it("handles null CyberArk data with 0 fallback", () => {
+    mockCyberArkSafesTotal = 0;
+    mockCyberArkRolesTotal = 0;
+    mockCyberArkPoliciesTotal = 0;
+    render(<DashboardPage />);
+    // The SummaryStatCard should show 0
+    const zeros = screen.getAllByText("0");
+    expect(zeros.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/ECSList.test.tsx
+++ b/frontend/src/pages/ECSList.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { ECSListPage } from "./ECSList";
+import type { ECSContainer, ECSClusterSummary } from "@/types";
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const mockContainer: ECSContainer = {
+  id: 1,
+  task_id: "task-abc123",
+  name: "web-task",
+  cluster_name: "prod-cluster",
+  launch_type: "FARGATE",
+  status: "RUNNING",
+  display_status: "active",
+  cpu: 256,
+  memory: 512,
+  task_definition_arn: null,
+  desired_status: null,
+  image: "my-repo/web-app",
+  image_tag: "latest",
+  container_port: 8080,
+  private_ip: "10.0.1.5",
+  subnet_id: null,
+  vpc_id: null,
+  availability_zone: null,
+  started_at: null,
+  tags: null,
+  tf_managed: false,
+  tf_state_source: null,
+  tf_resource_address: null,
+  updated_at: "2024-01-15T12:00:00Z",
+  managed_by: "terraform",
+  region_name: null,
+  is_deleted: false,
+  deleted_at: null,
+};
+
+const mockContainer2: ECSContainer = {
+  id: 2,
+  task_id: "task-def456",
+  name: "api-task",
+  cluster_name: "prod-cluster",
+  launch_type: "EC2",
+  status: "STOPPED",
+  display_status: "inactive",
+  cpu: 512,
+  memory: 2048,
+  task_definition_arn: null,
+  desired_status: null,
+  image: null,
+  image_tag: null,
+  container_port: null,
+  private_ip: null,
+  subnet_id: null,
+  vpc_id: null,
+  availability_zone: null,
+  started_at: null,
+  tags: null,
+  tf_managed: true,
+  tf_state_source: null,
+  tf_resource_address: null,
+  updated_at: "2024-01-14T12:00:00Z",
+  managed_by: "unmanaged",
+  region_name: null,
+  is_deleted: false,
+  deleted_at: null,
+};
+
+const mockCluster: ECSClusterSummary = {
+  cluster_name: "prod-cluster",
+  region_name: "us-east-1",
+  total_tasks: 2,
+  running_tasks: 1,
+  stopped_tasks: 1,
+  pending_tasks: 0,
+  tf_managed: false,
+  containers: [mockContainer, mockContainer2],
+  managed_by: "terraform",
+};
+
+let mockData: { data: ECSClusterSummary[] } | null = {
+  data: [mockCluster],
+};
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock("@/hooks", () => ({
+  useECSClusters: () => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+}));
+
+describe("ECSListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = { data: [mockCluster] };
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders ECS Containers heading", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("ECS Containers")).toBeInTheDocument();
+  });
+
+  it("renders summary cards", () => {
+    render(<ECSListPage />);
+    // "Clusters" appears as both a summary card label and card header
+    const clustersTexts = screen.getAllByText("Clusters");
+    expect(clustersTexts.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Total Tasks")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Stopped")).toBeInTheDocument();
+  });
+
+  it("renders cluster names", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("prod-cluster")).toBeInTheDocument();
+  });
+
+  it("renders region next to cluster name", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("(us-east-1)")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockIsLoading = true;
+    mockData = null;
+    const { container } = render(<ECSListPage />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    mockError = new Error("Failed");
+    mockData = null;
+    render(<ECSListPage />);
+    expect(screen.getByText("Error loading ECS clusters")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no clusters", () => {
+    mockData = { data: [] };
+    render(<ECSListPage />);
+    expect(screen.getByText("No ECS clusters found")).toBeInTheDocument();
+  });
+
+  it("shows search hint when empty with active search", () => {
+    mockData = { data: [] };
+    render(<ECSListPage />);
+    // When searchValue is empty, it shows the default message
+    expect(
+      screen.getByText("No ECS clusters are available in your account"),
+    ).toBeInTheDocument();
+  });
+
+  it("expands cluster on click and shows container rows", () => {
+    render(<ECSListPage />);
+    const clusterButton = screen.getByText("prod-cluster").closest("button")!;
+    fireEvent.click(clusterButton);
+    // After expanding, container names should be visible
+    expect(screen.getByText("web-task")).toBeInTheDocument();
+    expect(screen.getByText("api-task")).toBeInTheDocument();
+  });
+
+  it("collapses cluster on second click", () => {
+    render(<ECSListPage />);
+    const clusterButton = screen.getByText("prod-cluster").closest("button")!;
+    fireEvent.click(clusterButton);
+    expect(screen.getByText("web-task")).toBeInTheDocument();
+    fireEvent.click(clusterButton);
+    expect(screen.queryByText("web-task")).not.toBeInTheDocument();
+  });
+
+  it("shows container details - launch type, CPU/memory", () => {
+    render(<ECSListPage />);
+    const clusterButton = screen.getByText("prod-cluster").closest("button")!;
+    fireEvent.click(clusterButton);
+    expect(screen.getByText("FARGATE")).toBeInTheDocument();
+    expect(screen.getByText("256 CPU / 512 MB")).toBeInTheDocument();
+  });
+
+  it("formats memory >= 1024 as GB", () => {
+    render(<ECSListPage />);
+    const clusterButton = screen.getByText("prod-cluster").closest("button")!;
+    fireEvent.click(clusterButton);
+    expect(screen.getByText("512 CPU / 2.0 GB")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    render(<ECSListPage />);
+    expect(
+      screen.getByPlaceholderText("Search clusters..."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders total tasks count", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("shows running count badge on cluster", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("1 running")).toBeInTheDocument();
+  });
+
+  it("shows stopped count badge on cluster", () => {
+    render(<ECSListPage />);
+    expect(screen.getByText("1 stopped")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SetupPage.test.tsx
+++ b/frontend/src/pages/SetupPage.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import { SetupPage } from "./SetupPage";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+const mockNavigate = vi.fn();
+const mockSetTokens = vi.fn();
+let mockAuthConfig: { setup_required: boolean } | null = {
+  setup_required: true,
+};
+let mockAuthLoading = false;
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    authConfig: mockAuthConfig,
+    isLoading: mockAuthLoading,
+    setTokens: mockSetTokens,
+  }),
+}));
+
+const mockSetupAdmin = vi.fn();
+vi.mock("@/api/client", () => ({
+  setupAdmin: (...args: unknown[]) => mockSetupAdmin(...args),
+}));
+
+describe("SetupPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthConfig = { setup_required: true };
+    mockAuthLoading = false;
+    mockSetupAdmin.mockResolvedValue({
+      access_token: "token-123",
+      refresh_token: "refresh-456",
+    });
+  });
+
+  it("renders Initial Setup heading", () => {
+    render(<SetupPage />);
+    expect(screen.getByText("Initial Setup")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner when auth is loading", () => {
+    mockAuthLoading = true;
+    const { container } = render(<SetupPage />);
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("redirects to /login when setup_required is false", () => {
+    mockAuthConfig = { setup_required: false };
+    render(<SetupPage />);
+    expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true });
+  });
+
+  it("renders username, password, and confirmPassword inputs", () => {
+    render(<SetupPage />);
+    expect(screen.getByLabelText("Admin Username")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm Password")).toBeInTheDocument();
+  });
+
+  it("submit button disabled when fields empty", () => {
+    render(<SetupPage />);
+    const button = screen.getByRole("button", {
+      name: "Create Admin Account",
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("shows password validation checklist after typing", () => {
+    render(<SetupPage />);
+    const pwInput = screen.getByLabelText("Password");
+    fireEvent.change(pwInput, { target: { value: "a" } });
+    fireEvent.blur(pwInput);
+    expect(screen.getByText("At least 12 characters")).toBeInTheDocument();
+    expect(screen.getByText("One uppercase letter")).toBeInTheDocument();
+    expect(screen.getByText("One lowercase letter")).toBeInTheDocument();
+    expect(screen.getByText("One number")).toBeInTheDocument();
+    expect(screen.getByText("One special character")).toBeInTheDocument();
+  });
+
+  it("mismatched passwords show error", () => {
+    render(<SetupPage />);
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    fireEvent.change(pwInput, { target: { value: "Abc123!@#$xyz" } });
+    fireEvent.change(confirmInput, { target: { value: "different" } });
+    expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+  });
+
+  it("matching passwords show success", () => {
+    render(<SetupPage />);
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    const validPw = "Abc123!@#$xyz";
+    fireEvent.change(pwInput, { target: { value: validPw } });
+    fireEvent.change(confirmInput, { target: { value: validPw } });
+    expect(screen.getByText("Passwords match")).toBeInTheDocument();
+  });
+
+  it("submit button enabled when all fields valid", () => {
+    render(<SetupPage />);
+    const usernameInput = screen.getByLabelText("Admin Username");
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    const validPw = "Abc123!@#$xyz";
+
+    fireEvent.change(usernameInput, { target: { value: "admin" } });
+    fireEvent.change(pwInput, { target: { value: validPw } });
+    fireEvent.change(confirmInput, { target: { value: validPw } });
+
+    const button = screen.getByRole("button", {
+      name: "Create Admin Account",
+    });
+    expect(button).toBeEnabled();
+  });
+
+  it("successful submit calls setupAdmin and navigates", async () => {
+    render(<SetupPage />);
+    const usernameInput = screen.getByLabelText("Admin Username");
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    const validPw = "Abc123!@#$xyz";
+
+    fireEvent.change(usernameInput, { target: { value: "admin" } });
+    fireEvent.change(pwInput, { target: { value: validPw } });
+    fireEvent.change(confirmInput, { target: { value: validPw } });
+
+    const button = screen.getByRole("button", {
+      name: "Create Admin Account",
+    });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockSetupAdmin).toHaveBeenCalledWith({
+        username: "admin",
+        password: validPw,
+        confirm_password: validPw,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockSetTokens).toHaveBeenCalledWith("token-123", "refresh-456");
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    });
+  });
+
+  it("failed submit shows API error", async () => {
+    mockSetupAdmin.mockRejectedValueOnce({
+      response: { data: { detail: "Username already exists" } },
+    });
+
+    render(<SetupPage />);
+    const usernameInput = screen.getByLabelText("Admin Username");
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    const validPw = "Abc123!@#$xyz";
+
+    fireEvent.change(usernameInput, { target: { value: "admin" } });
+    fireEvent.change(pwInput, { target: { value: validPw } });
+    fireEvent.change(confirmInput, { target: { value: validPw } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create Admin Account" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Username already exists")).toBeInTheDocument();
+    });
+  });
+
+  it("button shows Creating account... while submitting", async () => {
+    // Make setupAdmin hang
+    mockSetupAdmin.mockImplementation(() => new Promise(() => {}));
+
+    render(<SetupPage />);
+    const usernameInput = screen.getByLabelText("Admin Username");
+    const pwInput = screen.getByLabelText("Password");
+    const confirmInput = screen.getByLabelText("Confirm Password");
+    const validPw = "Abc123!@#$xyz";
+
+    fireEvent.change(usernameInput, { target: { value: "admin" } });
+    fireEvent.change(pwInput, { target: { value: validPw } });
+    fireEvent.change(confirmInput, { target: { value: validPw } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create Admin Account" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Creating account...")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 22 new test files with 1,072+ total tests to bring frontend statement coverage from **52% to 80%**
- Covers previously untested pages, components, hooks, and pure utility functions
- Zero TypeScript errors, all tests passing, all files formatted

## Test Files Added (22)

**Topology Utilities (2):**
- `layoutCalculator.test.ts` — 23 tests for `calculateTopologyLayout` and `createEdges`
- `topologyFilter.test.ts` — 23 tests for `filterTopologyData` and `hasActiveFilters`

**Page Components (7):**
- `ECSList.test.tsx` — 16 tests (clusters, containers, expand/collapse, loading/error/empty)
- `SetupPage.test.tsx` — 12 tests (admin setup wizard, password validation, submit flow)
- `CyberArkPage.test.tsx` — 8 tests (tab navigation between resource types)
- `CyberArkUsersPage.test.tsx` — 13 tests (user table, filters, status badges)
- `AccessMappingPage.test.tsx` — 10 tests (loading/error/empty states, canvas rendering)
- `CyberArkDashboard.test.tsx` — 19 tests (stats cards, drift status, recent items)
- `Dashboard.cyberark.test.tsx` — 11 tests (CyberArk section of main dashboard)

**CyberArk Components (8):**
- `SafeList.test.tsx`, `RoleList.test.tsx`, `SIAPolicyList.test.tsx`, `UserList.test.tsx` — list views with search/filter/loading/error/empty
- `SafeDetailPanel.test.tsx`, `RoleDetailPanel.test.tsx`, `SIAPolicyDetailPanel.test.tsx` — detail panels with member/account tables
- `CyberArkTabNavigation.test.tsx` — tab switching and active state

**Access Mapping Components (3):**
- `AccessMappingLegend.test.tsx` — stats display, legend expand/collapse
- `AccessMappingFilterBar.test.tsx` — search, user selector, access type filter
- `AccessMappingDetailPanel.test.tsx` — account/EC2/RDS detail routing

**Settings & Hooks (2):**
- `CyberArkSettings.test.tsx` — 21 tests (platform API, SCIM, tenant discovery, sync status)
- `useResources.cyberark.test.ts` — 37 tests (all CyberArk/ECS/S3/access-mapping hooks + query keys)

## Test plan
- [x] `npx vitest run` — 1,072 tests pass (80 test files)
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [x] `npx vitest run --coverage` — 80.37% statement coverage
- [x] `npx prettier --write` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)